### PR TITLE
feat: adding tibiamaps.io link for npcs, adding tibia coords for npcs

### DIFF
--- a/api/npc_data.json
+++ b/api/npc_data.json
@@ -14,7 +14,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Ferumbras%27_Ascendant_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33450,32804,11:2",
+        "coords": [
+            33450,
+            32804,
+            11
+        ]
     },
     {
         "name": "A Bearded Woman",
@@ -34,6 +40,12 @@
             "I am NOT Princess Lumelia, you fools!",
             "Get a locksmith and free me or you will regret it, you foolish pirates!",
             "I am not a princess, I am an actor!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32594,31614,10:2",
+        "coords": [
+            32594,
+            31614,
+            10
         ]
     },
     {
@@ -51,7 +63,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Rise_of_Devovorga"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32936,31515,10:2",
+        "coords": [
+            32936,
+            31515,
+            10
+        ]
     },
     {
         "name": "A Beggar",
@@ -68,7 +86,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Dark_Trails_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33594,31956,7:2",
+        "coords": [
+            33594,
+            31956,
+            7
+        ]
     },
     {
         "name": "A Behemoth",
@@ -85,7 +109,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32308,32581,15:2",
+        "coords": [
+            32308,
+            32581,
+            15
+        ]
     },
     {
         "name": "A Confused Frog",
@@ -102,7 +132,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Scatterbrained_Sorcerer_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32289,32293,9:2",
+        "coords": [
+            32289,
+            32293,
+            9
+        ]
     },
     {
         "name": "A Dark Priestess",
@@ -119,7 +155,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Demon_Wars_World_Change"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33257,31935,15:2",
+        "coords": [
+            33257,
+            31935,
+            15
+        ]
     },
     {
         "name": "A Dead Bureaucrat",
@@ -139,6 +181,12 @@
         "dialogues": [
             "Now where did I put that form?",
             "Hail Pumin. Yes, hail."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32729,32292,15:2",
+        "coords": [
+            32729,
+            32292,
+            15
         ]
     },
     {
@@ -156,7 +204,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32278,32631,14:2",
+        "coords": [
+            32278,
+            32631,
+            14
+        ]
     },
     {
         "name": "A Dragon Mother",
@@ -176,6 +230,12 @@
         "dialogues": [
             "GRRR",
             "My egg is in danger!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32305,31019,13:2",
+        "coords": [
+            32305,
+            31019,
+            13
         ]
     },
     {
@@ -193,7 +253,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32233,32685,13:2",
+        "coords": [
+            32233,
+            32685,
+            13
+        ]
     },
     {
         "name": "A Dwarven Ghost",
@@ -205,7 +271,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.151-124.174-12-2-1-1",
         "version": "8.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32407,31917,12:2",
+        "coords": [
+            32407,
+            31917,
+            12
+        ]
     },
     {
         "name": "A Fading Memory",
@@ -222,7 +294,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32952,31439,3:2",
+        "coords": [
+            32952,
+            31439,
+            3
+        ]
     },
     {
         "name": "A Fluffy Squirrel",
@@ -236,6 +314,12 @@
         "quests": [],
         "dialogues": [
             "Chchch."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32412,31727,7:2",
+        "coords": [
+            32412,
+            31727,
+            7
         ]
     },
     {
@@ -253,7 +337,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Scatterbrained_Sorcerer_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32364,32118,7:2",
+        "coords": [
+            32364,
+            32118,
+            7
+        ]
     },
     {
         "name": "A Ghostly Guardian",
@@ -265,7 +355,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.243-126.90-14-2-1-1",
         "version": "7.9",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32755,32345,14:2",
+        "coords": [
+            32755,
+            32345,
+            14
+        ]
     },
     {
         "name": "A Ghostly Knight",
@@ -277,7 +373,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.88-126.70-11-2-1-1",
         "version": "7.9",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32856,32325,11:2",
+        "coords": [
+            32856,
+            32325,
+            11
+        ]
     },
     {
         "name": "A Ghostly Sage",
@@ -289,7 +391,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.60-125.245-10-2-1-1",
         "version": "7.9",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32828,32244,10:2",
+        "coords": [
+            32828,
+            32244,
+            10
+        ]
     },
     {
         "name": "A Ghostly Woman",
@@ -301,7 +409,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.190-124.65-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32190,31808,7:2",
+        "coords": [
+            32190,
+            31808,
+            7
+        ]
     },
     {
         "name": "A Ghostly Woman (Dream Realm)",
@@ -320,6 +434,12 @@
         ],
         "dialogues": [
             "Alone ... so alone. So cold."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32835,32288,14:2",
+        "coords": [
+            32835,
+            32288,
+            14
         ]
     },
     {
@@ -332,7 +452,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.200-123.244-8-2-1-1",
         "version": "10.90",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33736,31731,8:2",
+        "coords": [
+            33736,
+            31731,
+            8
+        ]
     },
     {
         "name": "A Grumpy Cyclops",
@@ -344,7 +470,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.54-122.8-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32822,31239,7:2",
+        "coords": [
+            32822,
+            31239,
+            7
+        ]
     },
     {
         "name": "A Lost Basher",
@@ -361,7 +493,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32172,32629,14:2",
+        "coords": [
+            32172,
+            32629,
+            14
+        ]
     },
     {
         "name": "A Lost Husher",
@@ -378,7 +516,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32211,32531,15:2",
+        "coords": [
+            32211,
+            32531,
+            15
+        ]
     },
     {
         "name": "A Lost Soul",
@@ -390,7 +534,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.211-124.182-14-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32211,31925,14:2",
+        "coords": [
+            32211,
+            31925,
+            14
+        ]
     },
     {
         "name": "A Lost Thrower",
@@ -407,7 +557,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32310,32544,14:2",
+        "coords": [
+            32310,
+            32544,
+            14
+        ]
     },
     {
         "name": "A Majestic Warwolf",
@@ -426,6 +582,12 @@
         ],
         "dialogues": [
             "YOOOOUHHOOOUU!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33353,31991,8:2",
+        "coords": [
+            33353,
+            31991,
+            8
         ]
     },
     {
@@ -443,7 +605,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32340,32530,13:2",
+        "coords": [
+            32340,
+            32530,
+            13
+        ]
     },
     {
         "name": "A Prisoner",
@@ -464,7 +632,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Paradox_Tower_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32393,32136,13:2",
+        "coords": [
+            32393,
+            32136,
+            13
+        ]
     },
     {
         "name": "A Restless Soul",
@@ -481,7 +655,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Ice_Islands_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32257,31100,10:2",
+        "coords": [
+            32257,
+            31100,
+            10
+        ]
     },
     {
         "name": "A Runaway Goblin",
@@ -498,7 +678,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Krailos_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33523,31668,8:2",
+        "coords": [
+            33523,
+            31668,
+            8
+        ]
     },
     {
         "name": "A Skull",
@@ -515,7 +701,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Grimvale_Quest/Spoiler#An_Ancient_Feud"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33165,32491,11:2",
+        "coords": [
+            33165,
+            32491,
+            11
+        ]
     },
     {
         "name": "A Sleeping Dragon",
@@ -532,7 +724,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33243,31218,10:2",
+        "coords": [
+            33243,
+            31218,
+            10
+        ]
     },
     {
         "name": "A Starving Dog",
@@ -552,6 +750,12 @@
         "dialogues": [
             "Sniff.",
             "Munch."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32119,31093,5:2",
+        "coords": [
+            32119,
+            31093,
+            5
         ]
     },
     {
@@ -573,6 +777,12 @@
             "I feel empty.",
             "So thirsty.",
             "Must be silent - real chalices rarely talk..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33419,31124,9:2",
+        "coords": [
+            33419,
+            31124,
+            9
         ]
     },
     {
@@ -590,7 +800,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Postman_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32910,32076,9:2",
+        "coords": [
+            32910,
+            32076,
+            9
+        ]
     },
     {
         "name": "A Swan",
@@ -607,7 +823,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Threatened_Dreams_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33185,31732,7:2",
+        "coords": [
+            33185,
+            31732,
+            7
+        ]
     },
     {
         "name": "A Sweaty Cyclops",
@@ -639,6 +861,12 @@
         "dialogues": [
             "Hum hum, huhum",
             "Silly lil' human"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32697,31673,3:2",
+        "coords": [
+            32697,
+            31673,
+            3
         ]
     },
     {
@@ -651,7 +879,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.211-124.182-14-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32211,31925,14:2",
+        "coords": [
+            32211,
+            31925,
+            14
+        ]
     },
     {
         "name": "A Tortured Soul",
@@ -663,7 +897,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.211-124.182-14-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32211,31925,14:2",
+        "coords": [
+            32211,
+            31925,
+            14
+        ]
     },
     {
         "name": "A Vulcongra",
@@ -680,7 +920,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32129,32558,13:2",
+        "coords": [
+            32129,
+            32558,
+            13
+        ]
     },
     {
         "name": "A Wandering Soul",
@@ -700,6 +946,12 @@
         "dialogues": [
             "Ooooh... the sadness...",
             "Leave me alone in my mourning..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32915,31489,7:2",
+        "coords": [
+            32915,
+            31489,
+            7
         ]
     },
     {
@@ -715,6 +967,12 @@
         "dialogues": [
             "485611800364197.",
             "78572611857643646724."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32788,31689,13:2",
+        "coords": [
+            32788,
+            31689,
+            13
         ]
     },
     {
@@ -732,7 +990,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32174,32598,15:2",
+        "coords": [
+            32174,
+            32598,
+            15
+        ]
     },
     {
         "name": "Abran Ironeye",
@@ -744,7 +1008,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.139-125.116-5-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32907,32115,5:2",
+        "coords": [
+            32907,
+            32115,
+            5
+        ]
     },
     {
         "name": "Absaan",
@@ -756,7 +1026,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.200-125.73-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32200,32072,13:2",
+        "coords": [
+            32200,
+            32072,
+            13
+        ]
     },
     {
         "name": "Absentminded Assistant",
@@ -768,7 +1044,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.216-127.79-11-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33752,32590,11:2",
+        "coords": [
+            33752,
+            32590,
+            11
+        ]
     },
     {
         "name": "Admiral Wyrmslicer",
@@ -780,7 +1062,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.140-128.53-3-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32396,32820,3:2",
+        "coords": [
+            32396,
+            32820,
+            3
+        ]
     },
     {
         "name": "Adrenius",
@@ -799,6 +1087,12 @@
         ],
         "dialogues": [
             "Hmmm, hmmm."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32660,32111,8:2",
+        "coords": [
+            32660,
+            32111,
+            8
         ]
     },
     {
@@ -814,6 +1108,12 @@
         "dialogues": [
             "Drome fighters! You can trade your hard earned drome points here!",
             "Fighters from the old arena still visit me to exchange their hard earned badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33203,32962,10:2",
+        "coords": [
+            33203,
+            32962,
+            10
         ]
     },
     {
@@ -841,6 +1141,12 @@
         ],
         "dialogues": [
             "Have a look at the largest sortiment of general goods in town."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33126,32809,6:2",
+        "coords": [
+            33126,
+            32809,
+            6
         ]
     },
     {
@@ -858,7 +1164,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Barbarian_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32415,31582,7:2",
+        "coords": [
+            32415,
+            31582,
+            7
+        ]
     },
     {
         "name": "Al Dee",
@@ -880,6 +1192,12 @@
             "Feeling lost? You can always ask me about general hints!",
             "Tools and general equipment at Al Dee's!",
             "Don't head for adventure without a rope and torches! Buy your supplies here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32063,32179,7:2",
+        "coords": [
+            32063,
+            32179,
+            7
         ]
     },
     {
@@ -898,6 +1216,12 @@
             "Judging by Baribas' remark on the quality of his latest sample, I wonder if he did not miscalculate the coefficient of the formula...",
             "<sigh> So much to do, so little time...",
             "Now where's that new specimen I collected?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33618,31883,4:2",
+        "coords": [
+            33618,
+            31883,
+            4
         ]
     },
     {
@@ -910,7 +1234,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.32-124.18-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33312,31761,7:2",
+        "coords": [
+            33312,
+            31761,
+            7
+        ]
     },
     {
         "name": "Alberto",
@@ -925,6 +1255,12 @@
         "dialogues": [
             "Drome fighters! You can trade your hard earned drome points here!",
             "Fighters from the old arena still visit me to exchange their hard earned badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32816,31811,12:2",
+        "coords": [
+            32816,
+            31811,
+            12
         ]
     },
     {
@@ -940,6 +1276,12 @@
         "dialogues": [
             "Walk in the light of Shaper wisdom!",
             "Our ways are the ways of the Shapers."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32335,32090,7:2",
+        "coords": [
+            32335,
+            32090,
+            7
         ]
     },
     {
@@ -954,6 +1296,12 @@
         "quests": [],
         "dialogues": [
             "Grmbl."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32953,32109,6:2",
+        "coords": [
+            32953,
+            32109,
+            6
         ]
     },
     {
@@ -971,7 +1319,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Efreet_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33048,32620,5:2",
+        "coords": [
+            33048,
+            32620,
+            5
+        ]
     },
     {
         "name": "Aletta",
@@ -983,7 +1337,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.5-127.55-10-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33797,32566,10:2",
+        "coords": [
+            33797,
+            32566,
+            10
+        ]
     },
     {
         "name": "Alexander",
@@ -995,7 +1355,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.232-124.95-3-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33256,31838,3:2",
+        "coords": [
+            33256,
+            31838,
+            3
+        ]
     },
     {
         "name": "Alia",
@@ -1007,7 +1373,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.104-124.41-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32360,31784,7:2",
+        "coords": [
+            32360,
+            31784,
+            7
+        ]
     },
     {
         "name": "Alissa",
@@ -1021,6 +1393,12 @@
         "quests": [],
         "dialogues": [
             "Fruit and vegetables, all fresh and tasty!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32091,32446,7:2",
+        "coords": [
+            32091,
+            32446,
+            7
         ]
     },
     {
@@ -1042,6 +1420,12 @@
             "Even the trees are sensing a greater evil.",
             "The wildlife is troubled.",
             "There are many hidden dangers lately."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32615,31734,7:2",
+        "coords": [
+            32615,
+            31734,
+            7
         ]
     },
     {
@@ -1056,6 +1440,12 @@
         "quests": [],
         "dialogues": [
             "Hey, need some furniture for your house? Come to the Plank and Treasurechest Market!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32991,32061,6:2",
+        "coords": [
+            32991,
+            32061,
+            6
         ]
     },
     {
@@ -1077,6 +1467,12 @@
             "Heeey there.",
             "Wanna talk?",
             "How are you?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33466,31323,7:2",
+        "coords": [
+            33466,
+            31323,
+            7
         ]
     },
     {
@@ -1089,7 +1485,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.107-125.125-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32875,32124,6:2",
+        "coords": [
+            32875,
+            32124,
+            6
+        ]
     },
     {
         "name": "Alyxo",
@@ -1110,6 +1512,12 @@
             "Ah, nothing inspires an actress like the sight of the sparkling ocean.",
             "Nothing against classical theatre. But fringe theatre has its own allure.",
             "I hope the Fafnar cultists don't cause even more trouble than they already have."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33941,31463,7:2",
+        "coords": [
+            33941,
+            31463,
+            7
         ]
     },
     {
@@ -1131,7 +1539,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Rest_in_Hallowed_Ground_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33222,31813,8:2",
+        "coords": [
+            33222,
+            31813,
+            8
+        ]
     },
     {
         "name": "Amarie",
@@ -1150,6 +1564,12 @@
         ],
         "dialogues": [
             "Please leave me alone... I have to study."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32692,31657,6:2",
+        "coords": [
+            32692,
+            31657,
+            6
         ]
     },
     {
@@ -1171,6 +1591,12 @@
             "What a beautiful palace. The Kilmareshians are highly skilful architects.",
             "The new treaty of amity and commerce with Kilmaresh is of utmost importance.",
             "The pending freight from the saffron coasts is overdue."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33873,31488,3:2",
+        "coords": [
+            33873,
+            31488,
+            3
         ]
     },
     {
@@ -1198,6 +1624,12 @@
             "What was that word again in Orcish language... hmm.",
             "Hey you! Are you an adventurer, too?",
             "<sings> Stormy weathers, stormy weathers... stormy weathers on the sea!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32103,32181,8:2",
+        "coords": [
+            32103,
+            32181,
+            8
         ]
     },
     {
@@ -1213,6 +1645,12 @@
         "dialogues": [
             "Welcome to the post office!",
             "If you need help with letters or parcels, just ask me. I can explain everything."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33800,32754,5:2",
+        "coords": [
+            33800,
+            32754,
+            5
         ]
     },
     {
@@ -1225,7 +1663,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.5-127.194-7-2-1-1",
         "version": "9.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33029,32705,7:2",
+        "coords": [
+            33029,
+            32705,
+            7
+        ]
     },
     {
         "name": "An Apparition",
@@ -1237,7 +1681,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.201-124.42-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32201,31785,7:2",
+        "coords": [
+            32201,
+            31785,
+            7
+        ]
     },
     {
         "name": "An Idol",
@@ -1254,7 +1704,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Adventures_of_Galthen_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32398,32508,7:2",
+        "coords": [
+            32398,
+            32508,
+            7
+        ]
     },
     {
         "name": "An Imprisoned Goblin",
@@ -1275,6 +1731,12 @@
             "Me so hungry...",
             "Frog God, hear poor goblin! Send help!...",
             "<groan>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33631,31714,10:2",
+        "coords": [
+            33631,
+            31714,
+            10
         ]
     },
     {
@@ -1289,6 +1751,12 @@
         "quests": [],
         "dialogues": [
             "AHHHH THE PAIN OF AGESSS! THE PAIN!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32796,31556,2:2",
+        "coords": [
+            32796,
+            31556,
+            2
         ]
     },
     {
@@ -1304,6 +1772,12 @@
         "dialogues": [
             "Grrrr.",
             "Fetchi maruk buta."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#31985,32156,7:2",
+        "coords": [
+            31985,
+            32156,
+            7
         ]
     },
     {
@@ -1318,6 +1792,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Tibia, Folda and Vega."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32127,31659,7:2",
+        "coords": [
+            32127,
+            31659,
+            7
         ]
     },
     {
@@ -1335,7 +1815,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Dream_Courts_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32759,32630,7:2",
+        "coords": [
+            32759,
+            32630,
+            7
+        ]
     },
     {
         "name": "Anerui",
@@ -1347,7 +1833,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.157-123.171-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32669,31658,7:2",
+        "coords": [
+            32669,
+            31658,
+            7
+        ]
     },
     {
         "name": "Aneus",
@@ -1359,7 +1851,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.170-123.178-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32426,31665,7:2",
+        "coords": [
+            32426,
+            31665,
+            7
+        ]
     },
     {
         "name": "Angelina",
@@ -1380,7 +1878,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Summoner_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32635,32401,10:2",
+        "coords": [
+            32635,
+            32401,
+            10
+        ]
     },
     {
         "name": "Angelo",
@@ -1397,7 +1901,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Cults_of_Tibia_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33283,32272,12:2",
+        "coords": [
+            33283,
+            32272,
+            12
+        ]
     },
     {
         "name": "Angus",
@@ -1418,7 +1928,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32670,32729,7:2",
+        "coords": [
+            32670,
+            32729,
+            7
+        ]
     },
     {
         "name": "Appaloosa",
@@ -1430,7 +1946,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.83-125.123-7-2-1-1",
         "version": "9.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32851,32122,7:2",
+        "coords": [
+            32851,
+            32122,
+            7
+        ]
     },
     {
         "name": "Ariella",
@@ -1457,6 +1979,12 @@
         ],
         "dialogues": [
             "Have a drink in Meriana's only tavern!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32336,32592,7:2",
+        "coords": [
+            32336,
+            32592,
+            7
         ]
     },
     {
@@ -1476,6 +2004,12 @@
         ],
         "dialogues": [
             "Come in, have a drink and something to eat."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33069,32885,6:2",
+        "coords": [
+            33069,
+            32885,
+            6
         ]
     },
     {
@@ -1490,6 +2024,12 @@
         "quests": [],
         "dialogues": [
             "Krrrrrng."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32224,31704,7:2",
+        "coords": [
+            32224,
+            31704,
+            7
         ]
     },
     {
@@ -1502,7 +2042,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.127-128.75-4-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33151,32842,4:2",
+        "coords": [
+            33151,
+            32842,
+            4
+        ]
     },
     {
         "name": "Arkulius",
@@ -1526,6 +2072,12 @@
             "...the minimum square deviation could cause a dislocation, in a matter of fact...",
             "...it could be possible to bring the sphere to a destination where...",
             "Yes, that's it! The elementary particle are corresponding to the... the ... UNBELIEVEABLE!!!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33280,31846,3:2",
+        "coords": [
+            33280,
+            31846,
+            3
         ]
     },
     {
@@ -1543,7 +2095,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32859,31324,7:2",
+        "coords": [
+            32859,
+            31324,
+            7
+        ]
     },
     {
         "name": "Arnold",
@@ -1555,7 +2113,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.177-125.70-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32945,32069,6:2",
+        "coords": [
+            32945,
+            32069,
+            6
+        ]
     },
     {
         "name": "Artemyth",
@@ -1570,6 +2134,12 @@
         "dialogues": [
             "Entrance to the pit? Just follow the trail of blood.",
             "Sissies!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33439,31832,9:2",
+        "coords": [
+            33439,
+            31832,
+            9
         ]
     },
     {
@@ -1584,6 +2154,12 @@
         "quests": [],
         "dialogues": [
             "Hey there, up for a chat?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32368,32214,7:2",
+        "coords": [
+            32368,
+            32214,
+            7
         ]
     },
     {
@@ -1601,7 +2177,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Repenters_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32769,31611,11:2",
+        "coords": [
+            32769,
+            31611,
+            11
+        ]
     },
     {
         "name": "Ashtamor",
@@ -1615,6 +2197,12 @@
         "quests": [],
         "dialogues": [
             "The passage to the afterlife is filled with obstacles, but I can help you with my wares."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32958,32087,6:2",
+        "coords": [
+            32958,
+            32087,
+            6
         ]
     },
     {
@@ -1627,7 +2215,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.195-126.145-7-2-1-1",
         "version": "7.6",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33219,32400,7:2",
+        "coords": [
+            33219,
+            32400,
+            7
+        ]
     },
     {
         "name": "Asnarus",
@@ -1639,7 +2233,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.5-126.127-7-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33541,32382,7:2",
+        "coords": [
+            33541,
+            32382,
+            7
+        ]
     },
     {
         "name": "Asphota",
@@ -1655,6 +2255,12 @@
             "Hammers, ropes, nets ...",
             "Tools available here!",
             "All kinds of tools - buy them here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33778,32843,6:2",
+        "coords": [
+            33778,
+            32843,
+            6
         ]
     },
     {
@@ -1669,6 +2275,12 @@
         "quests": [],
         "dialogues": [
             "Mooh! Tah!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32932,32073,11:2",
+        "coords": [
+            32932,
+            32073,
+            11
         ]
     },
     {
@@ -1689,6 +2301,12 @@
         "dialogues": [
             "Let me speak a few words to you.",
             "Death comes to the best of us, but this time you had no chance."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32097,32218,5:2",
+        "coords": [
+            32097,
+            32218,
+            5
         ]
     },
     {
@@ -1706,7 +2324,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Assassin_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32077,32532,9:2",
+        "coords": [
+            32077,
+            32532,
+            9
+        ]
     },
     {
         "name": "Atur",
@@ -1720,6 +2344,12 @@
         "quests": [],
         "dialogues": [
             "Don't forget to deposit your money here before you head out for adventure."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33948,31505,7:2",
+        "coords": [
+            33948,
+            31505,
+            7
         ]
     },
     {
@@ -1732,7 +2362,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.137-126.214-4-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32393,32469,4:2",
+        "coords": [
+            32393,
+            32469,
+            4
+        ]
     },
     {
         "name": "Aurita",
@@ -1753,6 +2389,12 @@
             "Sometimes it would be nice to have legs.",
             "Oh, Taegen ... *sigh*",
             "I'd like to take a walk on the beach."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33422,32261,7:2",
+        "coords": [
+            33422,
+            32261,
+            7
         ]
     },
     {
@@ -1765,7 +2407,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.246-126.129-7-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33526,32384,7:2",
+        "coords": [
+            33526,
+            32384,
+            7
+        ]
     },
     {
         "name": "Avan",
@@ -1777,7 +2425,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.246-127.60-9-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33782,32571,9:2",
+        "coords": [
+            33782,
+            32571,
+            9
+        ]
     },
     {
         "name": "Avar Tar",
@@ -1798,7 +2452,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Demon_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33250,31763,7:2",
+        "coords": [
+            33250,
+            31763,
+            7
+        ]
     },
     {
         "name": "Awareness of the Emperor",
@@ -1815,7 +2475,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33062,31152,15:2",
+        "coords": [
+            33062,
+            31152,
+            15
+        ]
     },
     {
         "name": "Azalea",
@@ -1831,6 +2497,12 @@
             "Flowers to liven up your house!",
             "Healing for your wounds and cures for your curses!",
             "Teaching fellow druids!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33593,31898,6:2",
+        "coords": [
+            33593,
+            31898,
+            6
         ]
     },
     {
@@ -1843,7 +2515,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.193-126.175-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33217,32430,7:2",
+        "coords": [
+            33217,
+            32430,
+            7
+        ]
     },
     {
         "name": "Baa'Leal",
@@ -1860,7 +2538,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Efreet_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33048,32619,4:2",
+        "coords": [
+            33048,
+            32619,
+            4
+        ]
     },
     {
         "name": "Balduin The Baker",
@@ -1874,6 +2558,12 @@
         "quests": [],
         "dialogues": [
             "I wonder if we will make it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33192,32397,7:2",
+        "coords": [
+            33192,
+            32397,
+            7
         ]
     },
     {
@@ -1886,7 +2576,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.90-122.91-6-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32346,31322,6:2",
+        "coords": [
+            32346,
+            31322,
+            6
+        ]
     },
     {
         "name": "Bambi Bonecrusher",
@@ -1898,7 +2594,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.85-124.5-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32341,31748,7:2",
+        "coords": [
+            32341,
+            31748,
+            7
+        ]
     },
     {
         "name": "Barazbaz",
@@ -1910,7 +2612,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.114-124.140-5-2-1-1",
         "version": "10.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33650,31883,5:2",
+        "coords": [
+            33650,
+            31883,
+            5
+        ]
     },
     {
         "name": "Barbara",
@@ -1922,7 +2630,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.59-124.8-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32315,31751,7:2",
+        "coords": [
+            32315,
+            31751,
+            7
+        ]
     },
     {
         "name": "Barnabas Dee",
@@ -1943,6 +2657,12 @@
             "Interesting equinox there. Maybe that was what caused the floods?",
             "Teaching spells to the brave sorcerers wandering the lands.",
             "Ah, the mysteries of the living and the dead."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33634,31879,4:2",
+        "coords": [
+            33634,
+            31879,
+            4
         ]
     },
     {
@@ -1958,6 +2678,12 @@
         "dialogues": [
             "Oh come on, leave already.",
             "What do you want here? This is my spot."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32142,32925,7:2",
+        "coords": [
+            32142,
+            32925,
+            7
         ]
     },
     {
@@ -1975,7 +2701,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32884,31159,7:2",
+        "coords": [
+            32884,
+            31159,
+            7
+        ]
     },
     {
         "name": "Barzak",
@@ -1987,7 +2719,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.206-125.69-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32206,32068,13:2",
+        "coords": [
+            32206,
+            32068,
+            13
+        ]
     },
     {
         "name": "Bashira",
@@ -2001,6 +2739,12 @@
         "quests": [],
         "dialogues": [
             "Welcome to Ab'Dendriel's store for general goods."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32669,31654,8:2",
+        "coords": [
+            32669,
+            31654,
+            8
         ]
     },
     {
@@ -2013,7 +2757,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.129-124.199-15-2-1-1",
         "version": "",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32641,31942,15:2",
+        "coords": [
+            32641,
+            31942,
+            15
+        ]
     },
     {
         "name": "Baxter",
@@ -2034,6 +2784,12 @@
             "The orcs are preparing for war!!!",
             "People of Thais, bring honour to your king by fighting in the orc war!",
             "Volunteer for the orc war!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32322,32187,7:2",
+        "coords": [
+            32322,
+            32187,
+            7
         ]
     },
     {
@@ -2048,6 +2804,12 @@
         "quests": [],
         "dialogues": [
             "Selling general goods and paperware! Come to my shop!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33214,31802,6:2",
+        "coords": [
+            33214,
+            31802,
+            6
         ]
     },
     {
@@ -2062,6 +2824,12 @@
         "quests": [],
         "dialogues": [
             "Grrrr."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32697,32774,7:2",
+        "coords": [
+            32697,
+            32774,
+            7
         ]
     },
     {
@@ -2083,6 +2851,12 @@
             "Nature is in pain.",
             "The weather is fine today.",
             "I can hear the call of the forest."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32596,31745,7:2",
+        "coords": [
+            32596,
+            31745,
+            7
         ]
     },
     {
@@ -2099,6 +2873,12 @@
             "Welcome to the post office!",
             "If you need help with letters or parcels, just ask me. I can explain everything.",
             "Hey, send a letter to your friend now and then. Keep in touch, you know."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32350,32218,7:2",
+        "coords": [
+            32350,
+            32218,
+            7
         ]
     },
     {
@@ -2113,6 +2893,12 @@
         "quests": [],
         "dialogues": [
             "I wonder if we will make it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32344,31822,7:2",
+        "coords": [
+            32344,
+            31822,
+            7
         ]
     },
     {
@@ -2133,6 +2919,12 @@
         "dialogues": [
             "Hiring courageous explorers for a mission!",
             "Need orichalcum pearls or an atlas? Get those here."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32359,32811,7:2",
+        "coords": [
+            32359,
+            32811,
+            7
         ]
     },
     {
@@ -2147,6 +2939,12 @@
         "quests": [],
         "dialogues": [
             "Hey there, need some general goods or paperware?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32318,31111,7:2",
+        "coords": [
+            32318,
+            31111,
+            7
         ]
     },
     {
@@ -2164,7 +2962,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32355,32795,7:2",
+        "coords": [
+            32355,
+            32795,
+            7
+        ]
     },
     {
         "name": "Bezil",
@@ -2178,6 +2982,12 @@
         "quests": [],
         "dialogues": [
             "Hey Nezil, let's go to the Jolly Axeman Tavern after business is done."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32657,31908,9:2",
+        "coords": [
+            32657,
+            31908,
+            9
         ]
     },
     {
@@ -2192,6 +3002,12 @@
         "quests": [],
         "dialogues": [
             "I wonder if we will make it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32347,32286,7:2",
+        "coords": [
+            32347,
+            32286,
+            7
         ]
     },
     {
@@ -2206,6 +3022,12 @@
         "quests": [],
         "dialogues": [
             "Always on guard."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32802,31790,10:2",
+        "coords": [
+            32802,
+            31790,
+            10
         ]
     },
     {
@@ -2226,6 +3048,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33023,32110,7:2",
+        "coords": [
+            33023,
+            32110,
+            7
         ]
     },
     {
@@ -2251,6 +3079,12 @@
             "Buying many types of food and ingredients, too!",
             "Hmm, hmm, now which ingredients do I need...",
             "Need food? I have plenty for sale!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32051,32203,7:2",
+        "coords": [
+            32051,
+            32203,
+            7
         ]
     },
     {
@@ -2265,6 +3099,12 @@
         "quests": [],
         "dialogues": [
             "I wonder if we will make it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32375,32801,7:2",
+        "coords": [
+            32375,
+            32801,
+            7
         ]
     },
     {
@@ -2284,6 +3124,12 @@
         ],
         "dialogues": [
             "Psst! Over here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32339,32205,6:2",
+        "coords": [
+            32339,
+            32205,
+            6
         ]
     },
     {
@@ -2296,7 +3142,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.102-125.130-4-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32102,32129,4:2",
+        "coords": [
+            32102,
+            32129,
+            4
+        ]
     },
     {
         "name": "Blossom Bonecrusher",
@@ -2308,7 +3160,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.143-124.19-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32399,31762,7:2",
+        "coords": [
+            32399,
+            31762,
+            7
+        ]
     },
     {
         "name": "Blubster",
@@ -2320,7 +3178,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.198-125.40-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32198,32039,13:2",
+        "coords": [
+            32198,
+            32039,
+            13
+        ]
     },
     {
         "name": "Bo'Ques",
@@ -2339,6 +3203,12 @@
         ],
         "dialogues": [
             "Now, where was I..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33101,32519,5:2",
+        "coords": [
+            33101,
+            32519,
+            5
         ]
     },
     {
@@ -2351,7 +3221,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.204-125.73-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32204,32072,13:2",
+        "coords": [
+            32204,
+            32072,
+            13
+        ]
     },
     {
         "name": "Bob The Worker",
@@ -2371,6 +3247,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33022,32107,6:2",
+        "coords": [
+            33022,
+            32107,
+            6
         ]
     },
     {
@@ -2383,7 +3265,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.21-122.206-10-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32533,31437,10:2",
+        "coords": [
+            32533,
+            31437,
+            10
+        ]
     },
     {
         "name": "Bonifacius",
@@ -2395,7 +3283,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.141-124.57-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33165,31800,7:2",
+        "coords": [
+            33165,
+            31800,
+            7
+        ]
     },
     {
         "name": "Boozer",
@@ -2414,6 +3308,12 @@
         ],
         "dialogues": [
             "Come have a drink in the Hard Rock Racing Track."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32921,32067,5:2",
+        "coords": [
+            32921,
+            32067,
+            5
         ]
     },
     {
@@ -2428,6 +3328,12 @@
         "quests": [],
         "dialogues": [
             "Get your furniture here. Or don't. Whatever."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32992,32067,6:2",
+        "coords": [
+            32992,
+            32067,
+            6
         ]
     },
     {
@@ -2440,7 +3346,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.144-126.225-4-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32400,32480,4:2",
+        "coords": [
+            32400,
+            32480,
+            4
+        ]
     },
     {
         "name": "Boveas",
@@ -2457,7 +3369,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Shadows_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32431,32088,15:2",
+        "coords": [
+            32431,
+            32088,
+            15
+        ]
     },
     {
         "name": "Bozarn",
@@ -2469,7 +3387,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.250-126.132-7-2-1-1",
         "version": "10.90",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33274,32387,7:2",
+        "coords": [
+            33274,
+            32387,
+            7
+        ]
     },
     {
         "name": "Bozo",
@@ -2491,6 +3415,12 @@
             "Do you know the one with the dragon? Where - and then ... hahahaha! Oh no, I guess I ruined it.",
             "The fools' guild? Are you serious? No, of course not! Hahaha!",
             "Welcome, welcome, step closer!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32313,32182,7:2",
+        "coords": [
+            32313,
+            32182,
+            7
         ]
     },
     {
@@ -2503,7 +3433,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.21-127.199-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32277,32710,7:2",
+        "coords": [
+            32277,
+            32710,
+            7
+        ]
     },
     {
         "name": "Bradford",
@@ -2526,6 +3462,12 @@
             "Ahem. <sings> The stars are so pretty, so pretty tonight...",
             "Ahem. <sings> Yo ho ho and a bottle of rum!",
             "Okay, now I need some rum to keep my throat wet."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32300,32836,7:2",
+        "coords": [
+            32300,
+            32836,
+            7
         ]
     },
     {
@@ -2538,7 +3480,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.180-123.101-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32692,31588,7:2",
+        "coords": [
+            32692,
+            31588,
+            7
+        ]
     },
     {
         "name": "Brengus",
@@ -2552,6 +3500,12 @@
         "quests": [],
         "dialogues": [
             "Best weapons and armors in town!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32634,32746,6:2",
+        "coords": [
+            32634,
+            32746,
+            6
         ]
     },
     {
@@ -2572,6 +3526,12 @@
         "dialogues": [
             "<hicks>",
             "Nobody knows the <hicks> trouble I've seen, la la la..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32595,32743,7:2",
+        "coords": [
+            32595,
+            32743,
+            7
         ]
     },
     {
@@ -2586,6 +3546,12 @@
         "quests": [],
         "dialogues": [
             "I wonder if we will make it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33249,31799,7:2",
+        "coords": [
+            33249,
+            31799,
+            7
         ]
     },
     {
@@ -2605,6 +3571,12 @@
         ],
         "dialogues": [
             "Come and take a look at the finest gems in the lands of Tibia."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32636,31666,8:2",
+        "coords": [
+            32636,
+            31666,
+            8
         ]
     },
     {
@@ -2617,7 +3589,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.101-124.125-9-2-1-1",
         "version": "12.70.10953",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32613,31868,9:2",
+        "coords": [
+            32613,
+            31868,
+            9
+        ]
     },
     {
         "name": "Brodrosch",
@@ -2631,6 +3609,12 @@
         "quests": [],
         "dialogues": [
             "Passage to Cormaya! Unforgettable steamboat ride!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32661,31956,15:2",
+        "coords": [
+            32661,
+            31956,
+            15
         ]
     },
     {
@@ -2648,7 +3632,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Elementalist_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33012,31543,10:2",
+        "coords": [
+            33012,
+            31543,
+            10
+        ]
     },
     {
         "name": "Brom",
@@ -2664,6 +3654,12 @@
             "Honour and glory!",
             "Stand against your foes!",
             "Let the stone drink blood!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32704,31831,12:2",
+        "coords": [
+            32704,
+            31831,
+            12
         ]
     },
     {
@@ -2681,7 +3677,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Barbarian_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32365,31626,7:2",
+        "coords": [
+            32365,
+            31626,
+            7
+        ]
     },
     {
         "name": "Bruce",
@@ -2698,7 +3700,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32741,31112,7:2",
+        "coords": [
+            32741,
+            31112,
+            7
+        ]
     },
     {
         "name": "Bruno",
@@ -2710,7 +3718,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.230-123.116-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32486,31603,7:2",
+        "coords": [
+            32486,
+            31603,
+            7
+        ]
     },
     {
         "name": "Brutus",
@@ -2726,6 +3740,12 @@
             "Let the sands scream red!",
             "Et you too, brute. Now move along.",
             "Duke it out in the arena!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33152,32983,8:2",
+        "coords": [
+            33152,
+            32983,
+            8
         ]
     },
     {
@@ -2745,6 +3765,12 @@
         ],
         "dialogues": [
             "I guess we made it this year!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33304,32062,7:2",
+        "coords": [
+            33304,
+            32062,
+            7
         ]
     },
     {
@@ -2757,7 +3783,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.254-121.219-7-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32254,31194,7:2",
+        "coords": [
+            32254,
+            31194,
+            7
+        ]
     },
     {
         "name": "Budrik",
@@ -2778,7 +3810,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Kissing_a_Pig_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32524,31905,8:2",
+        "coords": [
+            32524,
+            31905,
+            8
+        ]
     },
     {
         "name": "Bulltus",
@@ -2790,7 +3828,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.213-125.59-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32213,32058,13:2",
+        "coords": [
+            32213,
+            32058,
+            13
+        ]
     },
     {
         "name": "Bunny Bonecrusher",
@@ -2811,7 +3855,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Scatterbrained_Sorcerer_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32317,31750,5:2",
+        "coords": [
+            32317,
+            31750,
+            5
+        ]
     },
     {
         "name": "Burt",
@@ -2826,6 +3876,12 @@
         "dialogues": [
             "If you got to fight, you got to fight!",
             "Rotworms!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32767,31832,12:2",
+        "coords": [
+            32767,
+            31832,
+            12
         ]
     },
     {
@@ -2840,6 +3896,12 @@
         "quests": [],
         "dialogues": [
             "Behave yourself as long as you are in Carlin, commoner!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32294,31788,7:2",
+        "coords": [
+            32294,
+            31788,
+            7
         ]
     },
     {
@@ -2861,6 +3923,12 @@
             "I wish I could learn more about this strange world.",
             "Those different cultures are amazing.",
             "What an interesting continent."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33028,31512,10:2",
+        "coords": [
+            33028,
+            31512,
+            10
         ]
     },
     {
@@ -2873,7 +3941,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.202-128.68-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32202,32835,7:2",
+        "coords": [
+            32202,
+            32835,
+            7
+        ]
     },
     {
         "name": "Candra",
@@ -2885,7 +3959,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.193-128.60-4-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33729,32827,4:2",
+        "coords": [
+            33729,
+            32827,
+            4
+        ]
     },
     {
         "name": "Captain Bluebear",
@@ -2899,6 +3979,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Carlin, Ab'Dendriel, Edron, Venore, Port Hope, Liberty Bay, Yalahar, Roshamuul and Svargrond."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32310,32209,6:2",
+        "coords": [
+            32310,
+            32209,
+            6
         ]
     },
     {
@@ -2913,6 +3999,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Carlin, Venore and Thais."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32347,31107,6:2",
+        "coords": [
+            32347,
+            31107,
+            6
         ]
     },
     {
@@ -2927,6 +4019,12 @@
         "quests": [],
         "dialogues": [
             "By direct edict of the honorable Henricus, we are ordered to give passage for all recruits to Thais."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33493,32568,7:2",
+        "coords": [
+            33493,
+            32568,
+            7
         ]
     },
     {
@@ -2944,7 +4042,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/A_Pirate%27s_Tail_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33762,31335,7:2",
+        "coords": [
+            33762,
+            31335,
+            7
+        ]
     },
     {
         "name": "Captain Cookie",
@@ -2956,7 +4060,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.36-122.44-6-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32804,31275,6:2",
+        "coords": [
+            32804,
+            31275,
+            6
+        ]
     },
     {
         "name": "Captain Dreadnought",
@@ -2974,6 +4084,12 @@
             "No smuggling aboard this ship! Only 20 pieces of any creature product allowed!",
             "This island is too small. I need sea water around me.",
             "All aboard! Prepare to sail!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32031,31872,6:2",
+        "coords": [
+            32031,
+            31872,
+            6
         ]
     },
     {
@@ -2988,6 +4104,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Thais, Carlin, Ab'Dendriel, Port Hope, Edron, Darashia, Liberty Bay, Svargrond, Gray Island, Yalahar and Ankrahmun."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32955,32021,6:2",
+        "coords": [
+            32955,
+            32021,
+            6
         ]
     },
     {
@@ -3000,7 +4122,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.132-124.78-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32388,31821,6:2",
+        "coords": [
+            32388,
+            31821,
+            6
+        ]
     },
     {
         "name": "Captain Gulliver",
@@ -3016,6 +4144,12 @@
             "Passages to Thais! Visit the strange lands!",
             "Special passages to Edron, Venore, Port Hope or Krailos for citizens!",
             "Passages to Kilmaresh! Visit the city of Issavi and its architectural wonders!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33479,31987,7:2",
+        "coords": [
+            33479,
+            31987,
+            7
         ]
     },
     {
@@ -3038,6 +4172,12 @@
             "In the rigging ya lazy fools!",
             "I wanna see you movin' ya lazy fools!!",
             "Full sails!! There's a sea serpent to catch!!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32355,31124,6:2",
+        "coords": [
+            32355,
+            31124,
+            6
         ]
     },
     {
@@ -3054,6 +4194,12 @@
             "Bastesh's blessings!",
             "Passages to Oramond and Krailos!",
             "Come on board! The winds are prosperous!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33902,31461,6:2",
+        "coords": [
+            33902,
+            31461,
+            6
         ]
     },
     {
@@ -3066,7 +4212,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.189-124.213-6-2-1-1",
         "version": "7.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32189,31956,6:2",
+        "coords": [
+            32189,
+            31956,
+            6
+        ]
     },
     {
         "name": "Captain Jack Rat",
@@ -3083,7 +4235,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/A_Pirate%27s_Tail_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33792,31383,6:2",
+        "coords": [
+            33792,
+            31383,
+            6
+        ]
     },
     {
         "name": "Captain Kurt",
@@ -3097,6 +4255,12 @@
         "quests": [],
         "dialogues": [
             "Harr! Wanna go off this island? Need me an' my ship!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32099,31964,6:2",
+        "coords": [
+            32099,
+            31964,
+            6
         ]
     },
     {
@@ -3124,6 +4288,12 @@
         ],
         "dialogues": [
             "Whoah. That was a large shadow passing by."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#31914,32708,6:2",
+        "coords": [
+            31914,
+            32708,
+            6
         ]
     },
     {
@@ -3138,6 +4308,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Venore, Edron, Darashia, Issavi and Oramond."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33492,31709,6:2",
+        "coords": [
+            33492,
+            31709,
+            6
         ]
     },
     {
@@ -3150,7 +4326,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.223-123.180-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32735,31667,6:2",
+        "coords": [
+            32735,
+            31667,
+            6
+        ]
     },
     {
         "name": "Captain Seahorse",
@@ -3162,7 +4344,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.152-124.20-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33176,31763,6:2",
+        "coords": [
+            33176,
+            31763,
+            6
+        ]
     },
     {
         "name": "Captain Sinbeard",
@@ -3174,7 +4362,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.70-128.116-6-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33094,32883,6:2",
+        "coords": [
+            33094,
+            32883,
+            6
+        ]
     },
     {
         "name": "Captain Tiberius",
@@ -3188,6 +4382,12 @@
         "quests": [],
         "dialogues": [
             "Changed your mind? Travel back to the continent with me."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32062,32368,5:2",
+        "coords": [
+            32062,
+            32368,
+            5
         ]
     },
     {
@@ -3209,7 +4409,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Treasure_Hunt_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32347,32858,7:2",
+        "coords": [
+            32347,
+            32858,
+            7
+        ]
     },
     {
         "name": "Caramellia",
@@ -3224,6 +4430,12 @@
         "dialogues": [
             "Can I finally have some peace...?",
             "Please leave me alone in my mourning."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32588,31785,1:2",
+        "coords": [
+            32588,
+            31785,
+            1
         ]
     },
     {
@@ -3247,6 +4459,12 @@
         ],
         "dialogues": [
             "Fine jewels, rings and amulets!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33015,32047,6:2",
+        "coords": [
+            33015,
+            32047,
+            6
         ]
     },
     {
@@ -3259,7 +4477,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.23-123.204-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32023,31691,7:2",
+        "coords": [
+            32023,
+            31691,
+            7
+        ]
     },
     {
         "name": "Casper",
@@ -3276,7 +4500,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Last_Creep_Standing"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33261,32363,9:2",
+        "coords": [
+            33261,
+            32363,
+            9
+        ]
     },
     {
         "name": "Cedrik",
@@ -3290,6 +4520,12 @@
         "quests": [],
         "dialogues": [
             "Support your local weapon dealer!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32295,32817,7:2",
+        "coords": [
+            32295,
+            32817,
+            7
         ]
     },
     {
@@ -3307,7 +4543,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Druid_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32672,31713,7:2",
+        "coords": [
+            32672,
+            31713,
+            7
+        ]
     },
     {
         "name": "Cerdras",
@@ -3324,7 +4566,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Shadows_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32301,31815,6:2",
+        "coords": [
+            32301,
+            31815,
+            6
+        ]
     },
     {
         "name": "Cerebrir",
@@ -3343,6 +4591,12 @@
         ],
         "dialogues": [
             "This is a disaster!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32726,32737,11:2",
+        "coords": [
+            32726,
+            32737,
+            11
         ]
     },
     {
@@ -3360,7 +4614,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32363,32790,7:2",
+        "coords": [
+            32363,
+            32790,
+            7
+        ]
     },
     {
         "name": "Charles",
@@ -3375,6 +4635,12 @@
         "dialogues": [
             "Passages to Thais, Darashia, Edron, Venore, Ankrahmun, Liberty Bay, Oramond and Yalahar.",
             "Ahoy. Where can I sail you today?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32529,32784,6:2",
+        "coords": [
+            32529,
+            32784,
+            6
         ]
     },
     {
@@ -3387,7 +4653,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.13-128.73-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32269,32840,7:2",
+        "coords": [
+            32269,
+            32840,
+            7
+        ]
     },
     {
         "name": "Charos",
@@ -3399,7 +4671,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.210-126.40-6-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32210,32295,6:2",
+        "coords": [
+            32210,
+            32295,
+            6
+        ]
     },
     {
         "name": "Chartan",
@@ -3416,7 +4694,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33214,31057,9:2",
+        "coords": [
+            33214,
+            31057,
+            9
+        ]
     },
     {
         "name": "Chatterbone",
@@ -3430,6 +4714,12 @@
         "quests": [],
         "dialogues": [
             "Spelllsssssss..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32981,32079,6:2",
+        "coords": [
+            32981,
+            32079,
+            6
         ]
     },
     {
@@ -3447,7 +4737,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Oramond_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33547,31947,7:2",
+        "coords": [
+            33547,
+            31947,
+            7
+        ]
     },
     {
         "name": "Cheesy the Chosen",
@@ -3459,7 +4755,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.206-125.78-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32206,32077,13:2",
+        "coords": [
+            32206,
+            32077,
+            13
+        ]
     },
     {
         "name": "Chemar",
@@ -3474,6 +4776,12 @@
         "dialogues": [
             "Ask me if you need letters or parcels. I'll deliver them via airmail, of course!",
             "Feel the wind in your hair during one of my carpet rides!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33270,32438,6:2",
+        "coords": [
+            33270,
+            32438,
+            6
         ]
     },
     {
@@ -3488,6 +4796,12 @@
         "quests": [],
         "dialogues": [
             "Cooking utensils and kitchen equipment! For pros and starters!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32890,32076,6:2",
+        "coords": [
+            32890,
+            32076,
+            6
         ]
     },
     {
@@ -3515,6 +4829,12 @@
             "It's all a big conspiracy, mark my words.",
             "Not everything that walks our streets is human ... or even living.",
             "We are surrounded by myths, living and dead."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32348,32183,6:2",
+        "coords": [
+            32348,
+            32183,
+            6
         ]
     },
     {
@@ -3540,6 +4860,12 @@
             "Grarkharok's bestest troll tribe! Yeee, good name!",
             "Grarkharok make new tribe here! Me Chief now!",
             "Me like to throw rocks, me also like frogs! Yumyum!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33232,31754,1:2",
+        "coords": [
+            33232,
+            31754,
+            1
         ]
     },
     {
@@ -3552,7 +4878,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.162-123.214-7-2-1-1",
         "version": "9.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32418,31701,7:2",
+        "coords": [
+            32418,
+            31701,
+            7
+        ]
     },
     {
         "name": "Chondur",
@@ -3579,6 +4911,12 @@
         ],
         "dialogues": [
             "Spirits of the ancestors, guide me."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32360,32548,7:2",
+        "coords": [
+            32360,
+            32548,
+            7
         ]
     },
     {
@@ -3596,7 +4934,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33079,31021,2:2",
+        "coords": [
+            33079,
+            31021,
+            2
+        ]
     },
     {
         "name": "Christine",
@@ -3612,6 +4956,12 @@
             "Sho bee doo, shoo bee doo, shoo bee doo wah!",
             "La la laaa <sings>",
             "Cookies, cakes and cocktails! Fresh juices, toasts and sandwiches!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33612,31894,5:2",
+        "coords": [
+            33612,
+            31894,
+            5
         ]
     },
     {
@@ -3624,7 +4974,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.117-125.31-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32885,32030,6:2",
+        "coords": [
+            32885,
+            32030,
+            6
+        ]
     },
     {
         "name": "Chrystal",
@@ -3640,6 +4996,12 @@
             "Don't forget to include a label in your parcel!",
             "Welcome to the post office!",
             "If you need help with letters or parcels, just ask me. I can explain everything."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33174,31810,7:2",
+        "coords": [
+            33174,
+            31810,
+            7
         ]
     },
     {
@@ -3660,6 +5022,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33029,32096,6:2",
+        "coords": [
+            33029,
+            32096,
+            6
         ]
     },
     {
@@ -3672,7 +5040,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.21-122.4-5-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32789,31235,5:2",
+        "coords": [
+            32789,
+            31235,
+            5
+        ]
     },
     {
         "name": "Cillia",
@@ -3684,7 +5058,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.136-125.199-8-2-1-1",
         "version": "8.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32392,32198,8:2",
+        "coords": [
+            32392,
+            32198,
+            8
+        ]
     },
     {
         "name": "Cipfried",
@@ -3701,6 +5081,12 @@
             "Come to me if you need healing!",
             "Welcome to the temple of Rookgaard!",
             "Don't despair! Help is near!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32097,32216,7:2",
+        "coords": [
+            32097,
+            32216,
+            7
         ]
     },
     {
@@ -3713,7 +5099,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.124-128.28-7-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32636,32795,7:2",
+        "coords": [
+            32636,
+            32795,
+            7
+        ]
     },
     {
         "name": "Cledwyn",
@@ -3729,6 +5121,12 @@
             "Trading tokens! First-class bargains!",
             "Bespoke armor for all vocations! For the cost of some tokens only!",
             "Tokens! Bring your tokens!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32190,32291,7:2",
+        "coords": [
+            32190,
+            32291,
+            7
         ]
     },
     {
@@ -3743,6 +5141,12 @@
         "quests": [],
         "dialogues": [
             "Sit down, have a drink and relax!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32573,32752,7:2",
+        "coords": [
+            32573,
+            32752,
+            7
         ]
     },
     {
@@ -3760,7 +5164,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Ancient_Tombs_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33366,32854,14:2",
+        "coords": [
+            33366,
+            32854,
+            14
+        ]
     },
     {
         "name": "Coltrayne",
@@ -3781,6 +5191,12 @@
             "Don't go out unprepared! Get yourself some decent gear!",
             "Better armor means you take less damage - come and buy some decent chain mail!",
             "Skill comes with practice - get out there and kill some beasts!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32071,31880,5:2",
+        "coords": [
+            32071,
+            31880,
+            5
         ]
     },
     {
@@ -3798,7 +5214,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32804,31796,10:2",
+        "coords": [
+            32804,
+            31796,
+            10
+        ]
     },
     {
         "name": "Cornelia",
@@ -3812,6 +5234,12 @@
         "quests": [],
         "dialogues": [
             "Quality armors for sale!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32334,31795,7:2",
+        "coords": [
+            32334,
+            31795,
+            7
         ]
     },
     {
@@ -3826,6 +5254,12 @@
         "quests": [],
         "dialogues": [
             "Passage to Grimvale available here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33305,31719,7:2",
+        "coords": [
+            33305,
+            31719,
+            7
         ]
     },
     {
@@ -3843,7 +5277,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hidden_Threats_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33061,32006,12:2",
+        "coords": [
+            33061,
+            32006,
+            12
+        ]
     },
     {
         "name": "Corym Footman",
@@ -3860,7 +5300,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hidden_Threats_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32998,32050,12:2",
+        "coords": [
+            32998,
+            32050,
+            12
+        ]
     },
     {
         "name": "Corym Ratter",
@@ -3877,7 +5323,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hidden_Threats_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33035,32068,12:2",
+        "coords": [
+            33035,
+            32068,
+            12
+        ]
     },
     {
         "name": "Corym Servant",
@@ -3896,6 +5348,12 @@
         ],
         "dialogues": [
             "Our time will come! Nobody is born as a slave."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33033,32007,12:2",
+        "coords": [
+            33033,
+            32007,
+            12
         ]
     },
     {
@@ -3915,6 +5373,12 @@
         ],
         "dialogues": [
             "The time will come! The enslaved will rise up!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32998,32021,12:2",
+        "coords": [
+            32998,
+            32021,
+            12
         ]
     },
     {
@@ -3934,6 +5398,12 @@
         ],
         "dialogues": [
             "The time will come! The enslaved will rise up!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33051,32006,12:2",
+        "coords": [
+            33051,
+            32006,
+            12
         ]
     },
     {
@@ -3951,7 +5421,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_White_Raven_Monastery_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32180,31935,7:2",
+        "coords": [
+            32180,
+            31935,
+            7
+        ]
     },
     {
         "name": "Cranky Lizard Crone",
@@ -3972,7 +5448,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wayfarer_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33193,31044,6:2",
+        "coords": [
+            33193,
+            31044,
+            6
+        ]
     },
     {
         "name": "Crowned Tree",
@@ -3984,7 +5466,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.102-122.102-8-2-1-1",
         "version": "11.80.7048",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33382,31333,8:2",
+        "coords": [
+            33382,
+            31333,
+            8
+        ]
     },
     {
         "name": "Cruleo",
@@ -4005,6 +5493,12 @@
             "<gulp gulp>",
             "This will earn me some handsome amount of gold!",
             "Muhahaha!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32723,31787,7:2",
+        "coords": [
+            32723,
+            31787,
+            7
         ]
     },
     {
@@ -4029,6 +5523,12 @@
         "dialogues": [
             "There is no rage, there is control!",
             "There is no violence, there is grace!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33173,31394,7:2",
+        "coords": [
+            33173,
+            31394,
+            7
         ]
     },
     {
@@ -4041,7 +5541,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.205-126.153-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33229,32408,7:2",
+        "coords": [
+            33229,
+            32408,
+            7
+        ]
     },
     {
         "name": "Dagomir",
@@ -4053,7 +5559,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.250-125.47-5-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33018,32046,5:2",
+        "coords": [
+            33018,
+            32046,
+            5
+        ]
     },
     {
         "name": "Dal the Huntress",
@@ -4065,7 +5577,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.179-126.236-5-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32435,32491,5:2",
+        "coords": [
+            32435,
+            32491,
+            5
+        ]
     },
     {
         "name": "Dalbrect",
@@ -4086,7 +5604,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Family_Brooch_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32211,31754,6:2",
+        "coords": [
+            32211,
+            31754,
+            6
+        ]
     },
     {
         "name": "Dallheim",
@@ -4104,6 +5628,12 @@
             "I'll crush all monsters who dare to attack our base.",
             "Are you injured or poisoned? I can help you.",
             "For Rookgaard! For Tibia!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32093,32179,6:2",
+        "coords": [
+            32093,
+            32179,
+            6
         ]
     },
     {
@@ -4125,6 +5655,12 @@
             "Have you seen this beautiful butterfly? Sooo colourful!",
             "I just want to dance with my sisters.",
             "Trallallalllala."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33456,32295,7:2",
+        "coords": [
+            33456,
+            32295,
+            7
         ]
     },
     {
@@ -4137,7 +5673,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.52-124.94-8-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32308,31837,8:2",
+        "coords": [
+            32308,
+            31837,
+            8
+        ]
     },
     {
         "name": "Daniel Steelsoul",
@@ -4162,7 +5704,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Grimvale_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33191,31794,7:2",
+        "coords": [
+            33191,
+            31794,
+            7
+        ]
     },
     {
         "name": "Dankwart",
@@ -4177,6 +5725,12 @@
         "dialogues": [
             "Come to my tavern if you're hungry or thirsty, traveller.",
             "You'll never taste such fine mead and tea like here in this tavern."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32202,31161,7:2",
+        "coords": [
+            32202,
+            31161,
+            7
         ]
     },
     {
@@ -4189,7 +5743,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.192-128.182-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32192,32949,7:2",
+        "coords": [
+            32192,
+            32949,
+            7
+        ]
     },
     {
         "name": "Dario",
@@ -4204,6 +5764,12 @@
         "dialogues": [
             "Increase your knowledge of spells here, young paladin.",
             "Need ammunition, bows or crossbows? Have a look at my wares."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33156,32809,4:2",
+        "coords": [
+            33156,
+            32809,
+            4
         ]
     },
     {
@@ -4221,7 +5787,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Secret_Library_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33343,32020,7:2",
+        "coords": [
+            33343,
+            32020,
+            7
+        ]
     },
     {
         "name": "Deepling Idol",
@@ -4238,7 +5810,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33824,32525,14:2",
+        "coords": [
+            33824,
+            32525,
+            14
+        ]
     },
     {
         "name": "Demon Mother",
@@ -4254,6 +5832,12 @@
             "I want some days off.",
             "Oh no. Not again!",
             "Where is this brat again?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32633,32120,7:2",
+        "coords": [
+            32633,
+            32120,
+            7
         ]
     },
     {
@@ -4266,7 +5850,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.153-123.186-15-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32665,31673,15:2",
+        "coords": [
+            32665,
+            31673,
+            15
+        ]
     },
     {
         "name": "Demonguard",
@@ -4278,7 +5868,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.86-126.62-10-2-1-1",
         "version": "7.9",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32854,32317,10:2",
+        "coords": [
+            32854,
+            32317,
+            10
+        ]
     },
     {
         "name": "Demonic Messenger",
@@ -4290,7 +5886,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.16-122.225-12-2-1-1",
         "version": "10.90",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33296,31456,12:2",
+        "coords": [
+            33296,
+            31456,
+            12
+        ]
     },
     {
         "name": "Denominator",
@@ -4309,6 +5911,12 @@
         ],
         "dialogues": [
             "Numbers! Only Numbers!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33216,32142,9:2",
+        "coords": [
+            33216,
+            32142,
+            9
         ]
     },
     {
@@ -4326,7 +5934,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Postman_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32165,32436,7:2",
+        "coords": [
+            32165,
+            32436,
+            7
+        ]
     },
     {
         "name": "Dhira",
@@ -4338,7 +5952,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.193-128.90-7-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33729,32857,7:2",
+        "coords": [
+            33729,
+            32857,
+            7
+        ]
     },
     {
         "name": "Digger",
@@ -4352,6 +5972,12 @@
         "quests": [],
         "dialogues": [
             "Selling potions for humans and poison for undead creatures."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32970,32086,6:2",
+        "coords": [
+            32970,
+            32086,
+            6
         ]
     },
     {
@@ -4367,6 +5993,12 @@
         "dialogues": [
             "Bring your arena badges!",
             "Arena fighters visit me to exchange their hard earned arena badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32250,32143,11:2",
+        "coords": [
+            32250,
+            32143,
+            11
         ]
     },
     {
@@ -4385,6 +6017,12 @@
             "Don't forget to protect yourself with a shield!",
             "Selling the finest armors on Rookgaard!",
             "Don't let these mean monsters hurt you - get better equipment now!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32105,32206,6:2",
+        "coords": [
+            32105,
+            32206,
+            6
         ]
     },
     {
@@ -4397,7 +6035,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.77-127.8-3-2-1-1",
         "version": "7.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33101,32519,3:2",
+        "coords": [
+            33101,
+            32519,
+            3
+        ]
     },
     {
         "name": "Doctor Gnomedix",
@@ -4419,6 +6063,12 @@
             "All that dirt, incredible!",
             "Nothing is impossible for a gnomish doctor.",
             "Oh my!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32766,31769,10:2",
+        "coords": [
+            32766,
+            31769,
+            10
         ]
     },
     {
@@ -4431,7 +6081,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.56-125.174-6-2-1-1",
         "version": "9.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32312,32173,6:2",
+        "coords": [
+            32312,
+            32173,
+            6
+        ]
     },
     {
         "name": "Domizian",
@@ -4448,7 +6104,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Grimvale_Quest/Spoiler#An_Ancient_Feud"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33262,32462,6:2",
+        "coords": [
+            33262,
+            32462,
+            6
+        ]
     },
     {
         "name": "Donald McRonald",
@@ -4460,7 +6122,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.135-125.229-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32391,32228,7:2",
+        "coords": [
+            32391,
+            32228,
+            7
+        ]
     },
     {
         "name": "Dorbin",
@@ -4472,7 +6140,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.15-122.4-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32783,31235,7:2",
+        "coords": [
+            32783,
+            31235,
+            7
+        ]
     },
     {
         "name": "Dorian",
@@ -4489,7 +6163,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32317,32207,8:2",
+        "coords": [
+            32317,
+            32207,
+            8
+        ]
     },
     {
         "name": "Doubleday",
@@ -4506,7 +6186,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Oramond_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33640,31957,6:2",
+        "coords": [
+            33640,
+            31957,
+            6
+        ]
     },
     {
         "name": "Doug",
@@ -4518,7 +6204,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.197-127.243-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32197,32754,7:2",
+        "coords": [
+            32197,
+            32754,
+            7
+        ]
     },
     {
         "name": "Dove",
@@ -4534,6 +6226,12 @@
             "If you need help with letters or parcels, just ask me. I can explain everything.",
             "Welcome to the post office!",
             "No, no, I can't recommend parcel trade. It's better to meet your trading partner in person."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32919,32074,7:2",
+        "coords": [
+            32919,
+            32074,
+            7
         ]
     },
     {
@@ -4557,6 +6255,12 @@
             "<groan>",
             "<growl> <snarl> ROAAAARRRRR! <sob>",
             "To hold my dearest in my own arms again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33579,31867,12:2",
+        "coords": [
+            33579,
+            31867,
+            12
         ]
     },
     {
@@ -4569,7 +6273,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.120-123.46-10-2-1-1",
         "version": "9.60",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32888,31533,10:2",
+        "coords": [
+            32888,
+            31533,
+            10
+        ]
     },
     {
         "name": "Dreadeye",
@@ -4586,7 +6296,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Shadows_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32803,31571,14:2",
+        "coords": [
+            32803,
+            31571,
+            14
+        ]
     },
     {
         "name": "Dream Butterfly",
@@ -4606,6 +6322,12 @@
         "dialogues": [
             "Soothe, mend, dance, defend; ah, horror and fear, too near, too near.",
             "Whirring, whirling, meandering, lost, lost, lost..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33715,32377,6:2",
+        "coords": [
+            33715,
+            32377,
+            6
         ]
     },
     {
@@ -4618,7 +6340,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.3-124.206-14-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33539,31949,14:2",
+        "coords": [
+            33539,
+            31949,
+            14
+        ]
     },
     {
         "name": "Drog",
@@ -4635,7 +6363,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32533,31439,10:2",
+        "coords": [
+            32533,
+            31439,
+            10
+        ]
     },
     {
         "name": "Dronk",
@@ -4657,6 +6391,12 @@
             "Groam... is that you?",
             "Ack... my clothes are all soaked.",
             "Even the air down here is all damp..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32567,32021,9:2",
+        "coords": [
+            32567,
+            32021,
+            9
         ]
     },
     {
@@ -4674,6 +6414,12 @@
             "Sometimes it's not the loudest voice which has the most valuable information to give.",
             "If you like to choose a druid's way of life, talk to me.",
             "Follow your instincts and let nature guide you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32108,32003,7:2",
+        "coords": [
+            32108,
+            32003,
+            7
         ]
     },
     {
@@ -4691,7 +6437,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Glooth_Factory_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33702,31941,12:2",
+        "coords": [
+            33702,
+            31941,
+            12
+        ]
     },
     {
         "name": "Dukosch",
@@ -4705,6 +6457,12 @@
         "quests": [],
         "dialogues": [
             "Lorry tickets! A thrilling ride deep into the mountain!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32601,31871,7:2",
+        "coords": [
+            32601,
+            31871,
+            7
         ]
     },
     {
@@ -4722,7 +6480,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Meriana_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32336,32609,7:2",
+        "coords": [
+            32336,
+            32609,
+            7
+        ]
     },
     {
         "name": "Duria",
@@ -4734,7 +6498,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.105-124.194-8-2-1-1",
         "version": "6.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32617,31937,8:2",
+        "coords": [
+            32617,
+            31937,
+            8
+        ]
     },
     {
         "name": "Dustrunner",
@@ -4746,7 +6516,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.146-125.76-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32914,32075,6:2",
+        "coords": [
+            32914,
+            32075,
+            6
+        ]
     },
     {
         "name": "Dwarf Captain",
@@ -4765,6 +6541,12 @@
             "Is it already day outside? Is this still the night shift?!",
             "They always pick me for night shift. It's always me.",
             "Where's the replacement, isn't my shift already over?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33779,32172,14:2",
+        "coords": [
+            33779,
+            32172,
+            14
         ]
     },
     {
@@ -4781,6 +6563,12 @@
             "I don't like beer. Why didn't we ever create some alternative beverages?",
             "If this place is too dark for you, your eyes are too weak.",
             "We got to smoke them out, one way or another."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33772,32216,14:2",
+        "coords": [
+            33772,
+            32216,
+            14
         ]
     },
     {
@@ -4800,6 +6588,12 @@
             "Is it already day outside? Is this still the night shift?!",
             "They always pick me for night shift. It's always me.",
             "Where's the replacement, isn't my shift already over?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33838,32132,14:2",
+        "coords": [
+            33838,
+            32132,
+            14
         ]
     },
     {
@@ -4816,6 +6610,12 @@
             "I don't like beer. Why didn't we ever create some alternative beverages?",
             "If this place is too dark for you, your eyes are too weak.",
             "We got to smoke them out, one way or another."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33771,32202,14:2",
+        "coords": [
+            33771,
+            32202,
+            14
         ]
     },
     {
@@ -4832,6 +6632,12 @@
             "Is it already day outside? Is this still the night shift?!",
             "They always pick me for night shift. It's always me.",
             "Where's the replacement, isn't my shift already over?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33772,32205,14:2",
+        "coords": [
+            33772,
+            32205,
+            14
         ]
     },
     {
@@ -4848,6 +6654,12 @@
             "We got to smoke them out, one way or another.",
             "If this place is too dark for you, your eyes are too weak.",
             "I don't like beer. Why didn't we ever create some alternative beverages?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33794,32158,14:2",
+        "coords": [
+            33794,
+            32158,
+            14
         ]
     },
     {
@@ -4860,7 +6672,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.94-124.193-10-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32606,31936,10:2",
+        "coords": [
+            32606,
+            31936,
+            10
+        ]
     },
     {
         "name": "Eathar",
@@ -4872,7 +6690,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.0-124.204-13-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33536,31947,13:2",
+        "coords": [
+            33536,
+            31947,
+            13
+        ]
     },
     {
         "name": "Ebenizer",
@@ -4886,6 +6710,12 @@
         "quests": [],
         "dialogues": [
             "Don't forget to deposit your money here in the Tibian Bank before you head out for adventure."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33175,31800,7:2",
+        "coords": [
+            33175,
+            31800,
+            7
         ]
     },
     {
@@ -4910,6 +6740,12 @@
             "I'm so sorry... I promise it won't happen again. Problem is, I can't remember where I made the error...",
             "Actually, I STILL prefer inexperienced assistants. They're easier to keep an eye on and don't tend to backstab you.",
             "So much to do, so much to do... uh... where should I start?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32291,32290,7:2",
+        "coords": [
+            32291,
+            32290,
+            7
         ]
     },
     {
@@ -4927,7 +6763,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Diapason"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32698,31717,2:2",
+        "coords": [
+            32698,
+            31717,
+            2
+        ]
     },
     {
         "name": "Eddy",
@@ -4941,6 +6783,12 @@
         "quests": [],
         "dialogues": [
             "Have you moved to a new home? I'm the specialist for equipping it."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32168,32430,7:2",
+        "coords": [
+            32168,
+            32430,
+            7
         ]
     },
     {
@@ -4974,6 +6822,12 @@
             "One morning frosty fresh and nice, a knight was fishing on the ice. Catching some pikes for soup, but a dire penguin ate his loot. His angry wife said in the house: Now whole Beneva will laugh at us!",
             "A paladin slaying dragons on Antica's soil, when a lord charges on to make the adventurer's blood boil. It puts up a strong fight, but to no avail. It gets slain and drops a dragon scale mail!",
             "Through Rookgaard's sewer there swarmed no fewer than a hundred screeching rats. Wading through mud, and covered in blood, two young men fought back-to-back. To Trimera's end; a knight, and a friend."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32357,32187,7:2",
+        "coords": [
+            32357,
+            32187,
+            7
         ]
     },
     {
@@ -4989,6 +6843,12 @@
         "dialogues": [
             "Gems and jewellery, antiquities, wedding rings!",
             "Purchase a work of nature's beauty and men's art!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33624,31893,4:2",
+        "coords": [
+            33624,
+            31893,
+            4
         ]
     },
     {
@@ -5001,7 +6861,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.208-126.174-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33232,32429,7:2",
+        "coords": [
+            33232,
+            32429,
+            7
+        ]
     },
     {
         "name": "Edowir",
@@ -5015,6 +6881,12 @@
         "quests": [],
         "dialogues": [
             "I'm just an old man, but I know a lot about Tibia."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32343,32362,7:2",
+        "coords": [
+            32343,
+            32362,
+            7
         ]
     },
     {
@@ -5032,7 +6904,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33189,31787,7:2",
+        "coords": [
+            33189,
+            31787,
+            7
+        ]
     },
     {
         "name": "Edvard",
@@ -5044,7 +6922,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.205-124.87-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33229,31830,7:2",
+        "coords": [
+            33229,
+            31830,
+            7
+        ]
     },
     {
         "name": "Eighty",
@@ -5059,6 +6943,12 @@
         "dialogues": [
             "<beep>",
             "<beep> <crank> Use this device to manage your gold."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33452,31307,8:2",
+        "coords": [
+            33452,
+            31307,
+            8
         ]
     },
     {
@@ -5071,7 +6961,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.223-121.170-7-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32223,31145,7:2",
+        "coords": [
+            32223,
+            31145,
+            7
+        ]
     },
     {
         "name": "Elane",
@@ -5088,7 +6984,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hunter_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32343,32238,7:2",
+        "coords": [
+            32343,
+            32238,
+            7
+        ]
     },
     {
         "name": "Elathriel",
@@ -5100,7 +7002,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.172-123.183-9-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32684,31670,9:2",
+        "coords": [
+            32684,
+            31670,
+            9
+        ]
     },
     {
         "name": "Elbert",
@@ -5117,7 +7025,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Glooth_Factory_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33585,31987,12:2",
+        "coords": [
+            33585,
+            31987,
+            12
+        ]
     },
     {
         "name": "Eleonore",
@@ -5134,7 +7048,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Eleonore_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32332,32763,5:2",
+        "coords": [
+            32332,
+            32763,
+            5
+        ]
     },
     {
         "name": "Elf Guard",
@@ -5146,7 +7066,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.130-123.221-6-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32642,31708,6:2",
+        "coords": [
+            32642,
+            31708,
+            6
+        ]
     },
     {
         "name": "Eliyas",
@@ -5161,6 +7087,12 @@
         "dialogues": [
             "Buy bows, crossbows and ammunition here!",
             "Bows! Crossbows! Bolts and arrows! Buy them here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33915,31518,7:2",
+        "coords": [
+            33915,
+            31518,
+            7
         ]
     },
     {
@@ -5173,7 +7105,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.243-124.104-6-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33267,31847,6:2",
+        "coords": [
+            33267,
+            31847,
+            6
+        ]
     },
     {
         "name": "Elliott",
@@ -5196,6 +7134,12 @@
         ],
         "dialogues": [
             "We're on a mission from above."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33570,31907,8:2",
+        "coords": [
+            33570,
+            31907,
+            8
         ]
     },
     {
@@ -5208,7 +7152,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.157-123.119-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32669,31606,7:2",
+        "coords": [
+            32669,
+            31606,
+            7
+        ]
     },
     {
         "name": "Elyen Ravenlock",
@@ -5229,6 +7179,12 @@
             "<hums a dark tune>",
             "<chants> Re Ha, Omrah, Tan Ra...",
             "The rats... the rats in the walls..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33013,32358,11:2",
+        "coords": [
+            33013,
+            32358,
+            11
         ]
     },
     {
@@ -5243,6 +7199,12 @@
         "quests": [],
         "dialogues": [
             "Not enough space for all my trophies..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32197,32291,6:2",
+        "coords": [
+            32197,
+            32291,
+            6
         ]
     },
     {
@@ -5259,6 +7221,12 @@
             "Annual Autumn Vintaaage!",
             "You have a fine taste? You feel in touch with nature? Forget about that and help us gathering winterberries in time for everyone to enjoy!",
             "It's this time of the year again - help us gathering winterberries!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32358,32182,7:2",
+        "coords": [
+            32358,
+            32182,
+            7
         ]
     },
     {
@@ -5274,6 +7242,12 @@
         "dialogues": [
             "Drome fighters! You can trade your hard earned drome points here!",
             "Fighters from the old arena still visit me to exchange their hard earned badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33489,31814,9:2",
+        "coords": [
+            33489,
+            31814,
+            9
         ]
     },
     {
@@ -5289,6 +7263,12 @@
         "dialogues": [
             "Oh, my love. I know you are alive, somewhere!",
             "<sigh>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33612,31885,5:2",
+        "coords": [
+            33612,
+            31885,
+            5
         ]
     },
     {
@@ -5306,7 +7286,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Secret_Service_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32384,31780,6:2",
+        "coords": [
+            32384,
+            31780,
+            6
+        ]
     },
     {
         "name": "Emperor Kruzak",
@@ -5323,7 +7309,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Emperor%27s_Cookies_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32626,31922,3:2",
+        "coords": [
+            32626,
+            31922,
+            3
+        ]
     },
     {
         "name": "Emperor Rehal",
@@ -5340,7 +7332,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32584,31401,8:2",
+        "coords": [
+            32584,
+            31401,
+            8
+        ]
     },
     {
         "name": "Eranth",
@@ -5352,7 +7350,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.121-128.185-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32121,32952,7:2",
+        "coords": [
+            32121,
+            32952,
+            7
+        ]
     },
     {
         "name": "Erayo",
@@ -5369,7 +7373,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Assassin_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32519,32909,8:2",
+        "coords": [
+            32519,
+            32909,
+            8
+        ]
     },
     {
         "name": "Eremo",
@@ -5381,7 +7391,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.42-124.139-7-2-1-1",
         "version": "6.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33322,31882,7:2",
+        "coords": [
+            33322,
+            31882,
+            7
+        ]
     },
     {
         "name": "Eroth",
@@ -5398,7 +7414,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/To_Blind_the_Enemy_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32661,31684,6:2",
+        "coords": [
+            32661,
+            31684,
+            6
+        ]
     },
     {
         "name": "Eruaran",
@@ -5418,6 +7440,12 @@
         "dialogues": [
             "Bring your essences.",
             "Transformations! Bring your bad dreams."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33624,32368,5:2",
+        "coords": [
+            33624,
+            32368,
+            5
         ]
     },
     {
@@ -5430,7 +7458,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.33-127.49-10-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33825,32560,10:2",
+        "coords": [
+            33825,
+            32560,
+            10
+        ]
     },
     {
         "name": "Eshaya",
@@ -5451,6 +7485,12 @@
             "Praised be Suon and Bastesh.",
             "I should talk to Kallimae soon.",
             "Issavi's safety is my first concern."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33915,31497,6:2",
+        "coords": [
+            33915,
+            31497,
+            6
         ]
     },
     {
@@ -5463,7 +7503,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.12-123.42-10-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33036,31529,10:2",
+        "coords": [
+            33036,
+            31529,
+            10
+        ]
     },
     {
         "name": "Ethan",
@@ -5475,7 +7521,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.111-121.101-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32879,31076,7:2",
+        "coords": [
+            32879,
+            31076,
+            7
+        ]
     },
     {
         "name": "Etzel",
@@ -5491,6 +7543,12 @@
             "<coughs>",
             "Take care of you, young one. <coughs>",
             "Training young sorcerers. <coughs>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32626,31916,5:2",
+        "coords": [
+            32626,
+            31916,
+            5
         ]
     },
     {
@@ -5510,6 +7568,12 @@
         ],
         "dialogues": [
             "Always busy. Always in a hurry."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32936,32029,7:2",
+        "coords": [
+            32936,
+            32029,
+            7
         ]
     },
     {
@@ -5527,7 +7591,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/A_Pirate%27s_Tail_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33857,31331,9:2",
+        "coords": [
+            33857,
+            31331,
+            9
+        ]
     },
     {
         "name": "Eva",
@@ -5541,6 +7611,12 @@
         "quests": [],
         "dialogues": [
             "Better deposit your money in the bank where it's safe."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32325,31779,7:2",
+        "coords": [
+            32325,
+            31779,
+            7
         ]
     },
     {
@@ -5553,7 +7629,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.3-128.113-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32259,32880,7:2",
+        "coords": [
+            32259,
+            32880,
+            7
+        ]
     },
     {
         "name": "Evrard",
@@ -5565,7 +7647,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.148-126.237-6-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32404,32492,6:2",
+        "coords": [
+            32404,
+            32492,
+            6
+        ]
     },
     {
         "name": "Evrard the Miller",
@@ -5577,7 +7665,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.165-126.207-7-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32421,32462,7:2",
+        "coords": [
+            32421,
+            32462,
+            7
+        ]
     },
     {
         "name": "Excited Tibian",
@@ -5591,6 +7685,12 @@
         "quests": [],
         "dialogues": [
             "GIANT SPIDER BETWEEN VENORE AND KAZ, PLZ HELP!!!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32258,32115,13:2",
+        "coords": [
+            32258,
+            32115,
+            13
         ]
     },
     {
@@ -5603,7 +7703,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.199-121.83-9-2-1-1",
         "version": "8.60",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33223,31058,9:2",
+        "coords": [
+            33223,
+            31058,
+            9
+        ]
     },
     {
         "name": "Ezebeth",
@@ -5620,7 +7726,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Dark_Trails_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33675,31882,5:2",
+        "coords": [
+            33675,
+            31882,
+            5
+        ]
     },
     {
         "name": "Fa'Hradin",
@@ -5637,7 +7749,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Marid_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33106,32540,5:2",
+        "coords": [
+            33106,
+            32540,
+            5
+        ]
     },
     {
         "name": "Fabiana",
@@ -5652,6 +7770,12 @@
         "dialogues": [
             "Drome fighters! You can trade your hard earned drome points here!",
             "Fighters from the old arena still visit me to exchange their hard earned badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33539,31697,9:2",
+        "coords": [
+            33539,
+            31697,
+            9
         ]
     },
     {
@@ -5664,7 +7788,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.195-126.140-7-2-1-1",
         "version": "10.94",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33219,32395,7:2",
+        "coords": [
+            33219,
+            32395,
+            7
+        ]
     },
     {
         "name": "Falk",
@@ -5676,7 +7806,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.166-124.33-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33190,31776,7:2",
+        "coords": [
+            33190,
+            31776,
+            7
+        ]
     },
     {
         "name": "Falonzo",
@@ -5688,7 +7824,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.10-124.47-13-2-1-1",
         "version": "10.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33290,31790,13:2",
+        "coords": [
+            33290,
+            31790,
+            13
+        ]
     },
     {
         "name": "Faloriel",
@@ -5703,6 +7845,12 @@
         "dialogues": [
             "Health potions! Mana potions! Buy them here!",
             "All kinds of potions available here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33910,31513,7:2",
+        "coords": [
+            33910,
+            31513,
+            7
         ]
     },
     {
@@ -5715,7 +7863,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.148-123.185-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32660,31672,7:2",
+        "coords": [
+            32660,
+            31672,
+            7
+        ]
     },
     {
         "name": "Farhilorn of the Winter Court",
@@ -5727,7 +7881,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.238-125.48-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32238,32047,13:2",
+        "coords": [
+            32238,
+            32047,
+            13
+        ]
     },
     {
         "name": "Fayla",
@@ -5741,6 +7901,12 @@
         "quests": [],
         "dialogues": [
             "Do, re, mi, fa, so la, ti, do! <hums>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33640,31897,4:2",
+        "coords": [
+            33640,
+            31897,
+            4
         ]
     },
     {
@@ -5755,6 +7921,12 @@
         "quests": [],
         "dialogues": [
             "I sell furniture both to the mourned and the enlightened."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33066,32885,7:2",
+        "coords": [
+            33066,
+            32885,
+            7
         ]
     },
     {
@@ -5767,7 +7939,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.59-124.12-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32315,31755,7:2",
+        "coords": [
+            32315,
+            31755,
+            7
+        ]
     },
     {
         "name": "Fenech",
@@ -5781,6 +7959,12 @@
         "quests": [],
         "dialogues": [
             "Offering all sorts of magic equipment."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33131,32819,5:2",
+        "coords": [
+            33131,
+            32819,
+            5
         ]
     },
     {
@@ -5793,7 +7977,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.220-128.46-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32220,32813,7:2",
+        "coords": [
+            32220,
+            32813,
+            7
+        ]
     },
     {
         "name": "Ferks",
@@ -5807,6 +7997,12 @@
         "quests": [],
         "dialogues": [
             "Entrust us with your money and we will keep it safe in the bank."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32634,32737,6:2",
+        "coords": [
+            32634,
+            32737,
+            6
         ]
     },
     {
@@ -5822,6 +8018,12 @@
         "dialogues": [
             "Leaving for Meluna Island soon!",
             "Passage for newly weds only."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32153,32456,7:2",
+        "coords": [
+            32153,
+            32456,
+            7
         ]
     },
     {
@@ -5834,7 +8036,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.137-124.167-11-2-1-1",
         "version": "8.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32649,31910,11:2",
+        "coords": [
+            32649,
+            31910,
+            11
+        ]
     },
     {
         "name": "Fillias",
@@ -5850,6 +8058,12 @@
             "What? What? Is there anyone there? Oh. Just the wind.",
             "Shoo! Off with you, horrible pests!",
             "Hah. It will all end in tears, you mark my words. <mutters>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33573,31925,7:2",
+        "coords": [
+            33573,
+            31925,
+            7
         ]
     },
     {
@@ -5862,7 +8076,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.174-123.199-8-2-1-1",
         "version": "8.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32686,31686,8:2",
+        "coords": [
+            32686,
+            31686,
+            8
+        ]
     },
     {
         "name": "Fiona",
@@ -5874,7 +8094,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.1-124.102-5-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33281,31845,5:2",
+        "coords": [
+            33281,
+            31845,
+            5
+        ]
     },
     {
         "name": "Fitzmaurice",
@@ -5886,7 +8112,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.155-126.230-7-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32411,32485,7:2",
+        "coords": [
+            32411,
+            32485,
+            7
+        ]
     },
     {
         "name": "Flickering Soul",
@@ -5903,7 +8135,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Soul_War_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33621,31417,10:2",
+        "coords": [
+            33621,
+            31417,
+            10
+        ]
     },
     {
         "name": "Flint",
@@ -5917,6 +8155,12 @@
         "quests": [],
         "dialogues": [
             "Armor, melee weaponry, shields! Hand-crafted!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33635,31882,6:2",
+        "coords": [
+            33635,
+            31882,
+            6
         ]
     },
     {
@@ -5929,7 +8173,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.167-124.112-7-2-1-1",
         "version": "10.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33703,31855,7:2",
+        "coords": [
+            33703,
+            31855,
+            7
+        ]
     },
     {
         "name": "Florentine",
@@ -5943,6 +8193,12 @@
         "quests": [],
         "dialogues": [
             "Embellish your home with flowers!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32362,31795,7:2",
+        "coords": [
+            32362,
+            31795,
+            7
         ]
     },
     {
@@ -5960,7 +8216,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32586,31499,14:2",
+        "coords": [
+            32586,
+            31499,
+            14
+        ]
     },
     {
         "name": "Fral the Butcher",
@@ -5972,7 +8234,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.189-126.225-4-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32445,32480,4:2",
+        "coords": [
+            32445,
+            32480,
+            4
+        ]
     },
     {
         "name": "Frank The Plank",
@@ -5993,6 +8261,12 @@
             "Man, I'm starving. Where are those guys with the snacks Norman spoke of?",
             "You two! Having fun, are you? If you think being stuck here's funny, you can jolly well get back to Norman and get some planks out to us!",
             "Hey you! Yes, I mean you! Don't dawdle about and bring me that supply kit!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33046,32136,7:2",
+        "coords": [
+            33046,
+            32136,
+            7
         ]
     },
     {
@@ -6007,6 +8281,12 @@
         "quests": [],
         "dialogues": [
             "Aaaaah... ruuunes... waaaaaands... rooooods... spellboooooks..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32971,32079,6:2",
+        "coords": [
+            32971,
+            32079,
+            6
         ]
     },
     {
@@ -6019,7 +8299,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.89-128.40-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32345,32807,7:2",
+        "coords": [
+            32345,
+            32807,
+            7
+        ]
     },
     {
         "name": "Freezhild",
@@ -6036,7 +8322,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Secret_Service_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32020,31443,5:2",
+        "coords": [
+            32020,
+            31443,
+            5
+        ]
     },
     {
         "name": "Friedolin",
@@ -6052,6 +8344,12 @@
             "Join us, orange is where the fun is!",
             "Just for fun!",
             "What's with that sad face? Do something FUN for a change!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32342,31793,7:2",
+        "coords": [
+            32342,
+            31793,
+            7
         ]
     },
     {
@@ -6071,6 +8369,12 @@
         ],
         "dialogues": [
             "Come into my tavern and share some stories!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32356,32208,7:2",
+        "coords": [
+            32356,
+            32208,
+            7
         ]
     },
     {
@@ -6083,7 +8387,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.69-122.169-8-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32581,31400,8:2",
+        "coords": [
+            32581,
+            31400,
+            8
+        ]
     },
     {
         "name": "Frosty",
@@ -6099,6 +8409,12 @@
             "We are halfway out of the dark.",
             "Annoying perchts ... stinky, lousy, noisy creatures!",
             "Perchts! An ill-mannered bunch of brutes."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33833,31009,6:2",
+        "coords": [
+            33833,
+            31009,
+            6
         ]
     },
     {
@@ -6111,7 +8427,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.28-121.162-7-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32284,31137,7:2",
+        "coords": [
+            32284,
+            31137,
+            7
+        ]
     },
     {
         "name": "Fyodor",
@@ -6126,6 +8448,12 @@
         "dialogues": [
             "Letters! Parcels! Daily news!",
             "If you need help with letters or parcels, ask away. I can explain the system."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33639,31897,6:2",
+        "coords": [
+            33639,
+            31897,
+            6
         ]
     },
     {
@@ -6143,7 +8471,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Too_Hot_to_Handle_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32427,31151,15:2",
+        "coords": [
+            32427,
+            31151,
+            15
+        ]
     },
     {
         "name": "Gabel",
@@ -6164,7 +8498,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Killing_in_the_Name_of..._Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33102,32519,1:2",
+        "coords": [
+            33102,
+            32519,
+            1
+        ]
     },
     {
         "name": "Gaberiel",
@@ -6178,6 +8518,12 @@
         "quests": [],
         "dialogues": [
             "Get your green light!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32343,32213,7:2",
+        "coords": [
+            32343,
+            32213,
+            7
         ]
     },
     {
@@ -6192,6 +8538,12 @@
         "quests": [],
         "dialogues": [
             "I have gems and beautiful jewellery for you!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32621,32737,6:2",
+        "coords": [
+            32621,
+            32737,
+            6
         ]
     },
     {
@@ -6206,6 +8558,12 @@
         "quests": [],
         "dialogues": [
             "Bows, crossbows and ammunition on special sale today."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32342,32245,6:2",
+        "coords": [
+            32342,
+            32245,
+            6
         ]
     },
     {
@@ -6229,6 +8587,12 @@
         ],
         "dialogues": [
             "Pssst!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32337,32206,8:2",
+        "coords": [
+            32337,
+            32206,
+            8
         ]
     },
     {
@@ -6243,6 +8607,12 @@
         "quests": [],
         "dialogues": [
             "Any time's a good time to buy some furniture!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32408,32169,7:2",
+        "coords": [
+            32408,
+            32169,
+            7
         ]
     },
     {
@@ -6255,7 +8625,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.58-124.137-4-2-1-1",
         "version": "10.55",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32058,31880,4:2",
+        "coords": [
+            32058,
+            31880,
+            4
+        ]
     },
     {
         "name": "Gareth",
@@ -6269,6 +8645,12 @@
         "quests": [],
         "dialogues": [
             "Come in! Admire the variety of marvellous artworks from all over Tibia!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33305,32139,8:2",
+        "coords": [
+            33305,
+            32139,
+            8
         ]
     },
     {
@@ -6281,7 +8663,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.147-123.3-5-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32915,31490,5:2",
+        "coords": [
+            32915,
+            31490,
+            5
+        ]
     },
     {
         "name": "Gate Guardian",
@@ -6298,7 +8686,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33127,31196,7:2",
+        "coords": [
+            33127,
+            31196,
+            7
+        ]
     },
     {
         "name": "Gederas",
@@ -6310,7 +8704,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.216-127.35-7-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33496,32546,7:2",
+        "coords": [
+            33496,
+            32546,
+            7
+        ]
     },
     {
         "name": "Gelagos",
@@ -6327,7 +8727,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Barbarian_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32362,31623,7:2",
+        "coords": [
+            32362,
+            31623,
+            7
+        ]
     },
     {
         "name": "Gelidrazah's Thirst",
@@ -6344,7 +8750,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/First_Dragon_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32275,31365,4:2",
+        "coords": [
+            32275,
+            31365,
+            4
+        ]
     },
     {
         "name": "Geoffray",
@@ -6356,7 +8768,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.246-127.60-12-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33782,32571,12:2",
+        "coords": [
+            33782,
+            32571,
+            12
+        ]
     },
     {
         "name": "George The Boyscout",
@@ -6368,7 +8786,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.7-125.9-7-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33031,32008,7:2",
+        "coords": [
+            33031,
+            32008,
+            7
+        ]
     },
     {
         "name": "Georgia Rainbird",
@@ -6385,7 +8809,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Glooth_Factory_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33588,31906,12:2",
+        "coords": [
+            33588,
+            31906,
+            12
+        ]
     },
     {
         "name": "Gerimor",
@@ -6402,7 +8832,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Cults_of_Tibia_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33450,32245,7:2",
+        "coords": [
+            33450,
+            32245,
+            7
+        ]
     },
     {
         "name": "Gewen",
@@ -6416,6 +8852,12 @@
         "quests": [],
         "dialogues": [
             "Nothing beats the feeling of flying with a carpet!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32588,31940,0:2",
+        "coords": [
+            32588,
+            31940,
+            0
         ]
     },
     {
@@ -6437,6 +8879,12 @@
             "Great Hunger is upset.",
             "Spirits are restless.",
             "All water drying up and Vuzrog does nothing!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33628,31654,7:2",
+        "coords": [
+            33628,
+            31654,
+            7
         ]
     },
     {
@@ -6451,6 +8899,12 @@
         "quests": [],
         "dialogues": [
             "One day I will be free!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32169,32304,8:2",
+        "coords": [
+            32169,
+            32304,
+            8
         ]
     },
     {
@@ -6468,7 +8922,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32717,32574,12:2",
+        "coords": [
+            32717,
+            32574,
+            12
+        ]
     },
     {
         "name": "Ghostly Wolf",
@@ -6488,6 +8948,12 @@
         "dialogues": [
             "Grrrr.",
             "Yoooohhuuuu!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33335,32052,7:2",
+        "coords": [
+            33335,
+            32052,
+            7
         ]
     },
     {
@@ -6504,6 +8970,12 @@
             "Damn asuri!",
             "Perfidious hags!",
             "I shouldn't have left the camp!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32934,32671,5:2",
+        "coords": [
+            32934,
+            32671,
+            5
         ]
     },
     {
@@ -6519,6 +8991,12 @@
         "dialogues": [
             "Gems and jewellery! Best prices in town!",
             "If you are interested in gems and beautiful jewellery, I'm your man!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33820,32767,4:2",
+        "coords": [
+            33820,
+            32767,
+            4
         ]
     },
     {
@@ -6534,6 +9012,12 @@
         "dialogues": [
             "Fangs, fur, hooves ... if it comes from a were-creature I'll buy it!",
             "If you're in need of some tools, just ask me."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33348,31686,7:2",
+        "coords": [
+            33348,
+            31686,
+            7
         ]
     },
     {
@@ -6551,7 +9035,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33927,32116,15:2",
+        "coords": [
+            33927,
+            32116,
+            15
+        ]
     },
     {
         "name": "Gnomad",
@@ -6568,7 +9058,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32998,31917,10:2",
+        "coords": [
+            32998,
+            31917,
+            10
+        ]
     },
     {
         "name": "Gnomadness",
@@ -6585,7 +9081,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Primal_Ordeal_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33537,32871,14:2",
+        "coords": [
+            33537,
+            32871,
+            14
+        ]
     },
     {
         "name": "Gnomailion",
@@ -6602,6 +9104,12 @@
             "Now I will put that parcel ... ooops!",
             "How shall a little gnome handle such big parcels.",
             "Has this parcel just sneezed?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32794,31795,10:2",
+        "coords": [
+            32794,
+            31795,
+            10
         ]
     },
     {
@@ -6616,6 +9124,12 @@
         "quests": [],
         "dialogues": [
             "I have to order more supply packages soon."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32794,31745,10:2",
+        "coords": [
+            32794,
+            31745,
+            10
         ]
     },
     {
@@ -6633,7 +9147,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32243,32597,14:2",
+        "coords": [
+            32243,
+            32597,
+            14
+        ]
     },
     {
         "name": "Gnomaticus",
@@ -6650,7 +9170,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32766,31789,10:2",
+        "coords": [
+            32766,
+            31789,
+            10
+        ]
     },
     {
         "name": "Gnombold",
@@ -6667,7 +9193,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32243,32597,11:2",
+        "coords": [
+            32243,
+            32597,
+            11
+        ]
     },
     {
         "name": "Gnomcruiter",
@@ -6688,6 +9220,12 @@
             "I yearn the depths of earth.",
             "They really should turn of that sun more often.",
             "What an ungnomish place."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33256,31841,6:2",
+        "coords": [
+            33256,
+            31841,
+            6
         ]
     },
     {
@@ -6707,6 +9245,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33751,32153,15:2",
+        "coords": [
+            33751,
+            32153,
+            15
         ]
     },
     {
@@ -6726,6 +9270,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33740,32157,14:2",
+        "coords": [
+            33740,
+            32157,
+            14
         ]
     },
     {
@@ -6745,6 +9295,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33742,32160,15:2",
+        "coords": [
+            33742,
+            32160,
+            15
         ]
     },
     {
@@ -6761,6 +9317,12 @@
             "A gem is not a rock! Don't just play with it.",
             "This place could need some more green.",
             "What was that...?!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33754,32193,14:2",
+        "coords": [
+            33754,
+            32193,
+            14
         ]
     },
     {
@@ -6780,6 +9342,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33754,32142,14:2",
+        "coords": [
+            33754,
+            32142,
+            14
         ]
     },
     {
@@ -6796,6 +9364,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33754,32193,14:2",
+        "coords": [
+            33754,
+            32193,
+            14
         ]
     },
     {
@@ -6815,6 +9389,12 @@
             "'Do the night shift' they said. 'It will pay off' they said.",
             "I swear it's darker down here during nights, hmpf.",
             "Night shift. Again!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33757,32180,14:2",
+        "coords": [
+            33757,
+            32180,
+            14
         ]
     },
     {
@@ -6832,7 +9412,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32169,32650,13:2",
+        "coords": [
+            32169,
+            32650,
+            13
+        ]
     },
     {
         "name": "Gnomegica",
@@ -6847,6 +9433,12 @@
         "dialogues": [
             "Oh my, such a mess! I really should clean up things more often.",
             "Laaa Laaa LaLa Laa Laaa!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32805,31781,10:2",
+        "coords": [
+            32805,
+            31781,
+            10
         ]
     },
     {
@@ -6859,7 +9451,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.18-124.32-10-2-1-1",
         "version": "9.60",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32786,31775,10:2",
+        "coords": [
+            32786,
+            31775,
+            10
+        ]
     },
     {
         "name": "Gnomelvis",
@@ -6876,7 +9474,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32774,31804,10:2",
+        "coords": [
+            32774,
+            31804,
+            10
+        ]
     },
     {
         "name": "Gnomenace",
@@ -6888,7 +9492,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.209-125.37-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32209,32036,13:2",
+        "coords": [
+            32209,
+            32036,
+            13
+        ]
     },
     {
         "name": "Gnomenerdia",
@@ -6905,7 +9515,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Too_Hot_to_Handle_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32060,31392,15:2",
+        "coords": [
+            32060,
+            31392,
+            15
+        ]
     },
     {
         "name": "Gnomenezer",
@@ -6922,7 +9538,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32957,31954,9:2",
+        "coords": [
+            32957,
+            31954,
+            9
+        ]
     },
     {
         "name": "Gnomenursey",
@@ -6940,6 +9562,12 @@
             "<sigh>",
             "You are our hero, doctor Gnomedix.",
             "I wonder if we could spend some time together my daring doctor."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32766,31769,10:2",
+        "coords": [
+            32766,
+            31769,
+            10
         ]
     },
     {
@@ -6957,7 +9585,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32964,31877,9:2",
+        "coords": [
+            32964,
+            31877,
+            9
+        ]
     },
     {
         "name": "Gnomercy",
@@ -6974,7 +9608,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32991,31908,12:2",
+        "coords": [
+            32991,
+            31908,
+            12
+        ]
     },
     {
         "name": "Gnomerik",
@@ -6991,7 +9631,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32776,31745,10:2",
+        "coords": [
+            32776,
+            31745,
+            10
+        ]
     },
     {
         "name": "Gnomerrow",
@@ -7006,6 +9652,12 @@
         "dialogues": [
             "Outch! This one is quite pointy and sharp.",
             "Hm, pink burst arrows might be a breakthrough."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32786,31788,10:2",
+        "coords": [
+            32786,
+            31788,
+            10
         ]
     },
     {
@@ -7023,7 +9675,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32764,31753,10:2",
+        "coords": [
+            32764,
+            31753,
+            10
+        ]
     },
     {
         "name": "Gnomette",
@@ -7043,6 +9701,12 @@
         "dialogues": [
             "Always busy. So much to be done!",
             "Laaa Laaa LaLa Laa Laaa!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32799,31764,9:2",
+        "coords": [
+            32799,
+            31764,
+            9
         ]
     },
     {
@@ -7060,7 +9724,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Too_Hot_to_Handle_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32661,31824,10:2",
+        "coords": [
+            32661,
+            31824,
+            10
+        ]
     },
     {
         "name": "Gnomewart",
@@ -7077,7 +9747,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32757,31808,10:2",
+        "coords": [
+            32757,
+            31808,
+            10
+        ]
     },
     {
         "name": "Gnomfurry",
@@ -7089,7 +9765,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.249-128.134-14-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33529,32901,14:2",
+        "coords": [
+            33529,
+            32901,
+            14
+        ]
     },
     {
         "name": "Gnomillion",
@@ -7103,6 +9785,12 @@
         "quests": [],
         "dialogues": [
             "Interest rates are rising."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32825,31749,10:2",
+        "coords": [
+            32825,
+            31749,
+            10
         ]
     },
     {
@@ -7120,7 +9808,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32242,32597,9:2",
+        "coords": [
+            32242,
+            32597,
+            9
+        ]
     },
     {
         "name": "Gnomincia",
@@ -7137,7 +9831,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32979,31867,9:2",
+        "coords": [
+            32979,
+            31867,
+            9
+        ]
     },
     {
         "name": "Gnominer",
@@ -7154,7 +9854,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Primal_Ordeal_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33520,32880,14:2",
+        "coords": [
+            33520,
+            32880,
+            14
+        ]
     },
     {
         "name": "Gnominimus",
@@ -7175,6 +9881,12 @@
             "Hmmm.",
             "Secrets, secrets. So many secrets.",
             "What a strange place."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33696,32388,15:2",
+        "coords": [
+            33696,
+            32388,
+            15
         ]
     },
     {
@@ -7192,7 +9904,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32803,31758,10:2",
+        "coords": [
+            32803,
+            31758,
+            10
+        ]
     },
     {
         "name": "Gnomish Operative (Firefoot)",
@@ -7213,6 +9931,12 @@
             "Oh my, oh my.",
             "We are that close to a breakthrough discovery.",
             "What a mess."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33610,32838,15:2",
+        "coords": [
+            33610,
+            32838,
+            15
         ]
     },
     {
@@ -7234,6 +9958,12 @@
             "I hate heat!",
             "I hope we are done here soon.",
             "I need some water."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33708,32946,15:2",
+        "coords": [
+            33708,
+            32946,
+            15
         ]
     },
     {
@@ -7255,6 +9985,12 @@
             "I wonder what we will find out next.",
             "This place gives me shivers.",
             "What interesting data."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33586,32966,15:2",
+        "coords": [
+            33586,
+            32966,
+            15
         ]
     },
     {
@@ -7275,6 +10011,12 @@
         "dialogues": [
             "I think my new recalibration works ... probably.",
             "How interesting!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33702,32869,15:2",
+        "coords": [
+            33702,
+            32869,
+            15
         ]
     },
     {
@@ -7296,6 +10038,12 @@
             "Oh my!",
             "Only gnomish genius can prevent the end of the world now.",
             "Our time is running out."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33668,32924,15:2",
+        "coords": [
+            33668,
+            32924,
+            15
         ]
     },
     {
@@ -7313,7 +10061,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33007,31891,9:2",
+        "coords": [
+            33007,
+            31891,
+            9
+        ]
     },
     {
         "name": "Gnommander",
@@ -7330,7 +10084,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Spike_Tasks_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32248,32603,8:2",
+        "coords": [
+            32248,
+            32603,
+            8
+        ]
     },
     {
         "name": "Gnomole",
@@ -7347,7 +10107,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bigfoot%27s_Burden_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33008,31938,11:2",
+        "coords": [
+            33008,
+            31938,
+            11
+        ]
     },
     {
         "name": "Gnomoney",
@@ -7364,7 +10130,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Too_Hot_to_Handle_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32697,31768,10:2",
+        "coords": [
+            32697,
+            31768,
+            10
+        ]
     },
     {
         "name": "Gnomonster",
@@ -7376,7 +10148,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.165-123.229-11-2-1-1",
         "version": "12.70.10953",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32677,31716,11:2",
+        "coords": [
+            32677,
+            31716,
+            11
+        ]
     },
     {
         "name": "Gnomus",
@@ -7398,6 +10176,12 @@
             "I really wonder what takes them so long...",
             "Not long and all this uncharted territory will be us. Ah, a gnome can dream...",
             "Where are the reinforcements?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33749,32165,14:2",
+        "coords": [
+            33749,
+            32165,
+            14
         ]
     },
     {
@@ -7410,7 +10194,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.242-127.99-13-2-1-1",
         "version": "10.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32242,32610,13:2",
+        "coords": [
+            32242,
+            32610,
+            13
+        ]
     },
     {
         "name": "Gnomystery",
@@ -7422,7 +10212,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.98-124.134-9-2-1-1",
         "version": "12.70.10953",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32610,31877,9:2",
+        "coords": [
+            32610,
+            31877,
+            9
+        ]
     },
     {
         "name": "Golem Guardian",
@@ -7441,6 +10237,12 @@
             "Danger: Overheating.",
             "Target locked.",
             "Scanning human life form."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32803,31189,7:2",
+        "coords": [
+            32803,
+            31189,
+            7
         ]
     },
     {
@@ -7460,6 +10262,12 @@
         ],
         "dialogues": [
             "Failure is not an option!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32548,31250,9:2",
+        "coords": [
+            32548,
+            31250,
+            9
         ]
     },
     {
@@ -7472,7 +10280,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.185-128.2-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32185,32769,7:2",
+        "coords": [
+            32185,
+            32769,
+            7
+        ]
     },
     {
         "name": "Gorn",
@@ -7486,6 +10300,12 @@
         "quests": [],
         "dialogues": [
             "General goods and paperware for sale!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32377,32199,7:2",
+        "coords": [
+            32377,
+            32199,
+            7
         ]
     },
     {
@@ -7501,6 +10321,12 @@
         "dialogues": [
             "Self-defense and combat spells, easy to learn for everyone!",
             "Knight spells!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33611,31886,6:2",
+        "coords": [
+            33611,
+            31886,
+            6
         ]
     },
     {
@@ -7513,7 +10339,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.233-123.134-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32489,31621,7:2",
+        "coords": [
+            32489,
+            31621,
+            7
+        ]
     },
     {
         "name": "Gree Dee",
@@ -7530,6 +10362,12 @@
             "Come and buy at a cheap rate!",
             "Feel FREE to buy my ITEMS!",
             "Prepare well for your next adventure! Buy my wares!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32789,31235,6:2",
+        "coords": [
+            32789,
+            31235,
+            6
         ]
     },
     {
@@ -7547,7 +10385,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Knight_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32407,32201,6:2",
+        "coords": [
+            32407,
+            32201,
+            6
+        ]
     },
     {
         "name": "Grizzly Adams",
@@ -7567,6 +10411,12 @@
         "dialogues": [
             "Where is Ben, the old walking bag of fleas? Oh well, he'll come back when he's hungry.",
             "Hi there, do you want to join the 'Paw and Fur - Hunting Elite'?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32695,32765,6:2",
+        "coords": [
+            32695,
+            32765,
+            6
         ]
     },
     {
@@ -7586,6 +10436,12 @@
         ],
         "dialogues": [
             "One more drink and then I'll go home to my woman. ... sigh... I forgot - I don't have a woman."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32636,31878,9:2",
+        "coords": [
+            32636,
+            31878,
+            9
         ]
     },
     {
@@ -7603,7 +10459,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Inquisition_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32373,32183,7:2",
+        "coords": [
+            32373,
+            32183,
+            7
+        ]
     },
     {
         "name": "Grombur",
@@ -7624,7 +10486,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32611,31514,14:2",
+        "coords": [
+            32611,
+            31514,
+            14
+        ]
     },
     {
         "name": "Grubokk",
@@ -7644,6 +10512,12 @@
         "dialogues": [
             "<belch>",
             "Tasty snacks!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33683,31791,6:2",
+        "coords": [
+            33683,
+            31791,
+            6
         ]
     },
     {
@@ -7660,6 +10534,12 @@
             "Man, I wish I could join you treading, this must be the most boring job in all Tibia.",
             "Proper treading is essential for proper juice.",
             "Hey what are you doing there - leave that barrel alone!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32569,31565,8:2",
+        "coords": [
+            32569,
+            31565,
+            8
         ]
     },
     {
@@ -7677,7 +10557,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Threatened_Dreams_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32619,31863,7:2",
+        "coords": [
+            32619,
+            31863,
+            7
+        ]
     },
     {
         "name": "Guard Bazaya",
@@ -7689,7 +10575,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.144-123.39-7-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33936,31526,7:2",
+        "coords": [
+            33936,
+            31526,
+            7
+        ]
     },
     {
         "name": "Guard Inurta",
@@ -7701,7 +10593,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.77-123.9-4-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33869,31496,4:2",
+        "coords": [
+            33869,
+            31496,
+            4
+        ]
     },
     {
         "name": "Guard Saros",
@@ -7713,7 +10611,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.125-123.2-7-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33917,31489,7:2",
+        "coords": [
+            33917,
+            31489,
+            7
+        ]
     },
     {
         "name": "Guard Senet",
@@ -7725,7 +10629,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.73-123.5-7-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33865,31492,7:2",
+        "coords": [
+            33865,
+            31492,
+            7
+        ]
     },
     {
         "name": "Guardian of the Deep Seas",
@@ -7742,7 +10652,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Twenty_Miles_Beneath_the_Sea_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33547,31631,14:2",
+        "coords": [
+            33547,
+            31631,
+            14
+        ]
     },
     {
         "name": "Guide Alexena",
@@ -7754,7 +10670,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.126-124.67-7-2-1-1",
         "version": "8.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32382,31810,7:2",
+        "coords": [
+            32382,
+            31810,
+            7
+        ]
     },
     {
         "name": "Guide Behil",
@@ -7766,7 +10688,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.8-126.212-7-2-1-1",
         "version": "8.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33288,32467,7:2",
+        "coords": [
+            33288,
+            32467,
+            7
+        ]
     },
     {
         "name": "Guide Davina",
@@ -7783,6 +10711,12 @@
             "Hello, is this your first visit to Liberty Bay? I can show you around a little.",
             "Need some help finding your way through Liberty Bay? Let me assist you.",
             "Talk to me if you need directions."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32275,32894,6:2",
+        "coords": [
+            32275,
+            32894,
+            6
         ]
     },
     {
@@ -7795,7 +10729,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.37-122.36-6-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32805,31267,6:2",
+        "coords": [
+            32805,
+            31267,
+            6
+        ]
     },
     {
         "name": "Guide Elena",
@@ -7813,6 +10753,12 @@
             "I can inform you about the status of this world, if you're interested.",
             "Hello, is this your first visit to Venore? I can show you around a little.",
             "Need some help finding your way through Venore? Let me assist you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32952,32029,6:2",
+        "coords": [
+            32952,
+            32029,
+            6
         ]
     },
     {
@@ -7827,6 +10773,12 @@
         "quests": [],
         "dialogues": [
             "Need some help finding your way through Edron? Let me assist you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33181,31770,6:2",
+        "coords": [
+            33181,
+            31770,
+            6
         ]
     },
     {
@@ -7845,6 +10797,12 @@
             "Need some help finding your way through Rathleton? Let me assist you.",
             "I can inform you about the status of this world, if you're interested.",
             "Free escort to the depot for newcomers!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33493,31982,7:2",
+        "coords": [
+            33493,
+            31982,
+            7
         ]
     },
     {
@@ -7862,6 +10820,12 @@
             "Hello, is this your first visit to Thais? I can show you around a little.",
             "Need some help finding your way through Thais? Let me assist you.",
             "Talk to me if you need directions."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32319,32206,6:2",
+        "coords": [
+            32319,
+            32206,
+            6
         ]
     },
     {
@@ -7874,7 +10838,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.97-122.240-7-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33889,31471,7:2",
+        "coords": [
+            33889,
+            31471,
+            7
+        ]
     },
     {
         "name": "Guide Rahlkora",
@@ -7886,7 +10856,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.60-128.115-6-2-1-1",
         "version": "8.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33084,32882,6:2",
+        "coords": [
+            33084,
+            32882,
+            6
+        ]
     },
     {
         "name": "Guide Thelandil",
@@ -7898,7 +10874,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.214-123.175-6-2-1-1",
         "version": "8.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32726,31662,6:2",
+        "coords": [
+            32726,
+            31662,
+            6
+        ]
     },
     {
         "name": "Guide Tiko",
@@ -7913,6 +10895,12 @@
         "dialogues": [
             "Need some help finding your way through Port Hope? Let me assist you.",
             "Ask me if you want to know something about the world status!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32543,32785,6:2",
+        "coords": [
+            32543,
+            32785,
+            6
         ]
     },
     {
@@ -7927,6 +10915,12 @@
         "quests": [],
         "dialogues": [
             "Utevo vis lux!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33268,31848,5:2",
+        "coords": [
+            33268,
+            31848,
+            5
         ]
     },
     {
@@ -7939,7 +10933,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.33-124.245-15-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33313,31988,15:2",
+        "coords": [
+            33313,
+            31988,
+            15
+        ]
     },
     {
         "name": "H.L.",
@@ -7951,7 +10951,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.131-125.212-7-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32643,32211,7:2",
+        "coords": [
+            32643,
+            32211,
+            7
+        ]
     },
     {
         "name": "Haani",
@@ -7967,6 +10973,12 @@
             "Beds, chairs, decoration, flowers, instruments! Buy them here!",
             "Furniture on sale! Don't miss the opportunity.",
             "Furniture! Best prices in town!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33811,32771,4:2",
+        "coords": [
+            33811,
+            32771,
+            4
         ]
     },
     {
@@ -7979,7 +10991,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.201-126.178-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33225,32433,7:2",
+        "coords": [
+            33225,
+            32433,
+            7
+        ]
     },
     {
         "name": "Hagor",
@@ -7996,7 +11014,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Panpipe_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32654,32150,10:2",
+        "coords": [
+            32654,
+            32150,
+            10
+        ]
     },
     {
         "name": "Hairycles",
@@ -8019,6 +11043,12 @@
         ],
         "dialogues": [
             "Uh, uh."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32826,32573,6:2",
+        "coords": [
+            32826,
+            32573,
+            6
         ]
     },
     {
@@ -8036,7 +11066,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32688,31190,7:2",
+        "coords": [
+            32688,
+            31190,
+            7
+        ]
     },
     {
         "name": "Halif",
@@ -8048,7 +11084,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.193-126.167-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33217,32422,7:2",
+        "coords": [
+            33217,
+            32422,
+            7
+        ]
     },
     {
         "name": "Halvar",
@@ -8065,7 +11107,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Barbarian_Arena_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32230,31094,7:2",
+        "coords": [
+            32230,
+            31094,
+            7
+        ]
     },
     {
         "name": "Hamilton",
@@ -8077,7 +11125,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.199-128.25-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32199,32792,7:2",
+        "coords": [
+            32199,
+            32792,
+            7
+        ]
     },
     {
         "name": "Hamish",
@@ -8100,6 +11154,12 @@
             "Taking back empty potion flasks! Get your deposit back here!",
             "Careful with that! That's a highly reactive potion you have there!",
             "Mana potions to refill your magic power!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32058,31900,5:2",
+        "coords": [
+            32058,
+            31900,
+            5
         ]
     },
     {
@@ -8114,6 +11174,12 @@
         "quests": [],
         "dialogues": [
             "Gems and jewellery! Best prices in town!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32407,32218,7:2",
+        "coords": [
+            32407,
+            32218,
+            7
         ]
     },
     {
@@ -8128,6 +11194,12 @@
         "quests": [],
         "dialogues": [
             "Buying and selling all sorts of weapons and armors!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32272,32338,7:2",
+        "coords": [
+            32272,
+            32338,
+            7
         ]
     },
     {
@@ -8140,7 +11212,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.86-125.184-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32342,32183,7:2",
+        "coords": [
+            32342,
+            32183,
+            7
+        ]
     },
     {
         "name": "Harlow",
@@ -8152,7 +11230,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.88-123.60-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32856,31547,7:2",
+        "coords": [
+            32856,
+            31547,
+            7
+        ]
     },
     {
         "name": "Harog",
@@ -8164,7 +11248,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.80-122.213-9-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32592,31444,9:2",
+        "coords": [
+            32592,
+            31444,
+            9
+        ]
     },
     {
         "name": "Haroun",
@@ -8176,7 +11266,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.84-127.13-4-2-1-1",
         "version": "7.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33108,32524,4:2",
+        "coords": [
+            33108,
+            32524,
+            4
+        ]
     },
     {
         "name": "Harsky",
@@ -8188,7 +11284,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.56-125.170-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32312,32169,6:2",
+        "coords": [
+            32312,
+            32169,
+            6
+        ]
     },
     {
         "name": "Hawkhurst",
@@ -8200,7 +11302,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.77-124.240-7-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33357,31983,7:2",
+        "coords": [
+            33357,
+            31983,
+            7
+        ]
     },
     {
         "name": "Hawkyr",
@@ -8212,7 +11320,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.251-121.103-6-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32251,31078,6:2",
+        "coords": [
+            32251,
+            31078,
+            6
+        ]
     },
     {
         "name": "Heavenly Messenger",
@@ -8229,7 +11343,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Ferumbras%27_Ascension_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33388,31410,14:2",
+        "coords": [
+            33388,
+            31410,
+            14
+        ]
     },
     {
         "name": "Heliodor",
@@ -8241,7 +11361,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.111-126.70-12-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33135,32325,12:2",
+        "coords": [
+            33135,
+            32325,
+            12
+        ]
     },
     {
         "name": "Helor",
@@ -8255,6 +11381,12 @@
         "quests": [],
         "dialogues": [
             "Isn't the paladin class the mightiest of them all? I guess they are probably the most graceful at least."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32572,32752,6:2",
+        "coords": [
+            32572,
+            32752,
+            6
         ]
     },
     {
@@ -8270,6 +11402,12 @@
         "dialogues": [
             "Too dark down there? You must first embrace darkness if you truly want to defeat it!",
             "Garlic?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33535,31768,9:2",
+        "coords": [
+            33535,
+            31768,
+            9
         ]
     },
     {
@@ -8282,7 +11420,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.115-124.181-3-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32627,31924,3:2",
+        "coords": [
+            32627,
+            31924,
+            3
+        ]
     },
     {
         "name": "Henricus",
@@ -8299,7 +11443,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Inquisition_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32314,32265,8:2",
+        "coords": [
+            32314,
+            32265,
+            8
+        ]
     },
     {
         "name": "Herbert",
@@ -8316,7 +11466,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32332,32838,7:2",
+        "coords": [
+            32332,
+            32838,
+            7
+        ]
     },
     {
         "name": "Hercule",
@@ -8332,6 +11488,12 @@
             "Be a legend in the arena! Maybe almost as legendary as me!",
             "Be an example - just like me!",
             "If you would be even half as good as I once was..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33151,32983,10:2",
+        "coords": [
+            33151,
+            32983,
+            10
         ]
     },
     {
@@ -8344,7 +11506,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.22-124.201-14-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33558,31944,14:2",
+        "coords": [
+            33558,
+            31944,
+            14
+        ]
     },
     {
         "name": "Hjaern",
@@ -8365,7 +11533,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32349,31025,7:2",
+        "coords": [
+            32349,
+            31025,
+            7
+        ]
     },
     {
         "name": "Hofech",
@@ -8377,7 +11551,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.246-126.185-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33270,32440,7:2",
+        "coords": [
+            33270,
+            32440,
+            7
+        ]
     },
     {
         "name": "Hoggle",
@@ -8400,6 +11580,12 @@
         ],
         "dialogues": [
             "Oh, this misery..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32537,32142,6:2",
+        "coords": [
+            32537,
+            32142,
+            6
         ]
     },
     {
@@ -8423,6 +11609,12 @@
         ],
         "dialogues": [
             "Ahh! A vision! I have a vision for a new outfit! Assistant, some paper, fast!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32951,32102,5:2",
+        "coords": [
+            32951,
+            32102,
+            5
         ]
     },
     {
@@ -8442,6 +11634,12 @@
         ],
         "dialogues": [
             "Come, come my little babies... food for you!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32598,31879,9:2",
+        "coords": [
+            32598,
+            31879,
+            9
         ]
     },
     {
@@ -8454,7 +11652,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.115-124.177-3-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32627,31920,3:2",
+        "coords": [
+            32627,
+            31920,
+            3
+        ]
     },
     {
         "name": "Humphrey",
@@ -8466,7 +11670,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.103-123.195-6-2-1-1",
         "version": "7.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32359,31682,6:2",
+        "coords": [
+            32359,
+            31682,
+            6
+        ]
     },
     {
         "name": "Huntsman",
@@ -8483,7 +11693,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Overhunting"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32648,31731,7:2",
+        "coords": [
+            32648,
+            31731,
+            7
+        ]
     },
     {
         "name": "Hyacinth",
@@ -8500,7 +11716,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Rookie_Guard_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32137,32170,4:2",
+        "coords": [
+            32137,
+            32170,
+            4
+        ]
     },
     {
         "name": "Ikassis",
@@ -8521,6 +11743,12 @@
             "Perhaps we shouldn't have come here.",
             "I pity this poor mother.",
             "The wildlife is troubled."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33127,31712,7:2",
+        "coords": [
+            33127,
+            31712,
+            7
         ]
     },
     {
@@ -8535,6 +11763,12 @@
         "quests": [],
         "dialogues": [
             "Fresh food! Finest quality!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32335,31799,7:2",
+        "coords": [
+            32335,
+            31799,
+            7
         ]
     },
     {
@@ -8547,7 +11781,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.46-128.13-7-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32558,32780,7:2",
+        "coords": [
+            32558,
+            32780,
+            7
+        ]
     },
     {
         "name": "Inigo",
@@ -8567,6 +11807,12 @@
             "Come to me if you need directions!",
             "Buying all sorts of creature products!",
             "Troll hair, wolf fur, lumps of dirt - bring them to me!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32072,31899,5:2",
+        "coords": [
+            32072,
+            31899,
+            5
         ]
     },
     {
@@ -8579,7 +11825,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.112-123.30-7-2-1-1",
         "version": "12.20.8834",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33904,31517,7:2",
+        "coords": [
+            33904,
+            31517,
+            7
+        ]
     },
     {
         "name": "Innkeeper Alphonse",
@@ -8591,7 +11843,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.161-126.245-7-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32417,32500,7:2",
+        "coords": [
+            32417,
+            32500,
+            7
+        ]
     },
     {
         "name": "Iptar-Sin",
@@ -8607,6 +11865,12 @@
             "Suon is the protector of Kilmaresh, then and now.",
             "May Suon's light guide you.",
             "Praised be Suon, the Benevolent King!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33919,31475,5:2",
+        "coords": [
+            33919,
+            31475,
+            5
         ]
     },
     {
@@ -8619,7 +11883,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.176-123.122-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32688,31609,7:2",
+        "coords": [
+            32688,
+            31609,
+            7
+        ]
     },
     {
         "name": "Iriana",
@@ -8636,7 +11906,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Top_of_the_City_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32849,31299,7:2",
+        "coords": [
+            32849,
+            31299,
+            7
+        ]
     },
     {
         "name": "Irmana",
@@ -8657,7 +11933,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Threatened_Dreams_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32952,32109,5:2",
+        "coords": [
+            32952,
+            32109,
+            5
+        ]
     },
     {
         "name": "Irvin",
@@ -8669,7 +11951,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.190-127.221-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32190,32732,7:2",
+        "coords": [
+            32190,
+            32732,
+            7
+        ]
     },
     {
         "name": "Ishebad",
@@ -8681,7 +11969,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.134-128.80-7-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33158,32847,7:2",
+        "coords": [
+            33158,
+            32847,
+            7
+        ]
     },
     {
         "name": "Ishina",
@@ -8693,7 +11987,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.207-126.167-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33231,32422,7:2",
+        "coords": [
+            33231,
+            32422,
+            7
+        ]
     },
     {
         "name": "Isika",
@@ -8708,6 +12008,12 @@
         "dialogues": [
             "Buy bows, crossbows and ammunition here!",
             "Bows! Crossbows! Bolts and arrows! Buy them here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33773,32839,6:2",
+        "coords": [
+            33773,
+            32839,
+            6
         ]
     },
     {
@@ -8727,6 +12033,12 @@
         ],
         "dialogues": [
             "The life of a dwarf is an eternal struggle. It hardens us and makes us the fine race we are, jawoll."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32653,31924,11:2",
+        "coords": [
+            32653,
+            31924,
+            11
         ]
     },
     {
@@ -8744,7 +12056,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Ice_Islands_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32301,31082,7:2",
+        "coords": [
+            32301,
+            31082,
+            7
+        ]
     },
     {
         "name": "Isolde",
@@ -8756,7 +12074,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.158-128.62-4-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32414,32829,4:2",
+        "coords": [
+            32414,
+            32829,
+            4
+        ]
     },
     {
         "name": "Ivalisse",
@@ -8777,6 +12101,12 @@
             "Behold the makings of the Shapers!",
             "I wonder how papa does...",
             "Imbuing means to do the Shapers' will!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32329,32090,7:2",
+        "coords": [
+            32329,
+            32090,
+            7
         ]
     },
     {
@@ -8789,7 +12119,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.8-127.31-11-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33800,32542,11:2",
+        "coords": [
+            33800,
+            32542,
+            11
+        ]
     },
     {
         "name": "Iwan",
@@ -8801,7 +12137,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.193-124.89-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33217,31832,7:2",
+        "coords": [
+            33217,
+            31832,
+            7
+        ]
     },
     {
         "name": "Iwar",
@@ -8815,6 +12157,12 @@
         "quests": [],
         "dialogues": [
             "You moving to new home? Me specialist for equipping it."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32618,31916,8:2",
+        "coords": [
+            32618,
+            31916,
+            8
         ]
     },
     {
@@ -8830,6 +12178,12 @@
         "dialogues": [
             "A... aargh. I wish I had some e... earmuffs to put over this useless t... turban.",
             "Oh p.. please. P... lease let me fly us out of this c... cold."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32253,31096,4:2",
+        "coords": [
+            32253,
+            31096,
+            4
         ]
     },
     {
@@ -8847,7 +12201,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33080,31215,5:2",
+        "coords": [
+            33080,
+            31215,
+            5
+        ]
     },
     {
         "name": "Izzkl",
@@ -8859,7 +12219,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.199-125.57-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32199,32056,13:2",
+        "coords": [
+            32199,
+            32056,
+            13
+        ]
     },
     {
         "name": "Jack",
@@ -8881,6 +12247,12 @@
             "So much to do, so little time, they say...",
             "Could it be...? No. No way.",
             "Mh..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33277,31754,7:2",
+        "coords": [
+            33277,
+            31754,
+            7
         ]
     },
     {
@@ -8895,6 +12267,12 @@
         "quests": [],
         "dialogues": [
             "Passages to Edron, Thais, Venore, Darashia, Ankrahmun, Yalahar and Port Hope."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32161,32555,6:2",
+        "coords": [
+            32161,
+            32555,
+            6
         ]
     },
     {
@@ -8915,6 +12293,12 @@
         "dialogues": [
             "Always be on guard.",
             "Hmm."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32329,32258,9:2",
+        "coords": [
+            32329,
+            32258,
+            9
         ]
     },
     {
@@ -8935,6 +12319,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33032,32103,6:2",
+        "coords": [
+            33032,
+            32103,
+            6
         ]
     },
     {
@@ -8958,6 +12348,12 @@
         ],
         "dialogues": [
             "Darn, I hate this."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33571,31982,9:2",
+        "coords": [
+            33571,
+            31982,
+            9
         ]
     },
     {
@@ -8970,7 +12366,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.9-124.215-8-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32521,31958,8:2",
+        "coords": [
+            32521,
+            31958,
+            8
+        ]
     },
     {
         "name": "Jakahr",
@@ -8982,7 +12384,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.42-128.108-7-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33066,32875,7:2",
+        "coords": [
+            33066,
+            32875,
+            7
+        ]
     },
     {
         "name": "James",
@@ -8996,6 +12404,12 @@
         "quests": [],
         "dialogues": [
             "Food of the finest quality! Right here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33280,31770,7:2",
+        "coords": [
+            33280,
+            31770,
+            7
         ]
     },
     {
@@ -9013,7 +12427,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Cults_of_Tibia_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#31942,32502,8:2",
+        "coords": [
+            31942,
+            32502,
+            8
+        ]
     },
     {
         "name": "Janz",
@@ -9027,6 +12447,12 @@
         "quests": [],
         "dialogues": [
             "Moved into a new house? I got the perfect furniture for you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32279,31131,7:2",
+        "coords": [
+            32279,
+            31131,
+            7
         ]
     },
     {
@@ -9039,7 +12465,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.158-128.172-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32158,32939,7:2",
+        "coords": [
+            32158,
+            32939,
+            7
+        ]
     },
     {
         "name": "Jata",
@@ -9056,6 +12488,12 @@
             "I know all the world changes and the status the world is in. If you're interested, I can inform you.",
             "Need some help finding your way through Marapur? Let me assist you.",
             "Talk to me if you need directions."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33809,32850,7:2",
+        "coords": [
+            33809,
+            32850,
+            7
         ]
     },
     {
@@ -9068,7 +12506,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.238-125.53-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33006,32052,6:2",
+        "coords": [
+            33006,
+            32052,
+            6
+        ]
     },
     {
         "name": "Jean Pierre",
@@ -9085,7 +12529,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hot_Cuisine_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33068,32530,6:2",
+        "coords": [
+            33068,
+            32530,
+            6
+        ]
     },
     {
         "name": "Jefrey",
@@ -9099,6 +12549,12 @@
         "quests": [],
         "dialogues": [
             "You'll sleep much better after a hunt once you have sold your loot and brought your money to our bank."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32340,32833,7:2",
+        "coords": [
+            32340,
+            32833,
+            7
         ]
     },
     {
@@ -9111,7 +12567,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.165-126.225-4-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32421,32480,4:2",
+        "coords": [
+            32421,
+            32480,
+            4
+        ]
     },
     {
         "name": "Jerom",
@@ -9132,6 +12594,12 @@
             "My house! Uahahahaha <sniffs>.",
             "Dear gods! My precious house, DESTROYED!!",
             "Oh no!! What am I supposed to do now?!?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33239,31756,7:2",
+        "coords": [
+            33239,
+            31756,
+            7
         ]
     },
     {
@@ -9147,6 +12615,12 @@
         "dialogues": [
             "Gems, jewels... all a woman could dream of is right here.",
             "Leave your money with me where it's safe!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32299,31135,7:2",
+        "coords": [
+            32299,
+            31135,
+            7
         ]
     },
     {
@@ -9161,6 +12635,12 @@
         "quests": [],
         "dialogues": [
             "Food of various kinds, have a look."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33126,32820,6:2",
+        "coords": [
+            33126,
+            32820,
+            6
         ]
     },
     {
@@ -9173,7 +12653,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.124-124.142-9-2-1-1",
         "version": "6.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32636,31885,9:2",
+        "coords": [
+            32636,
+            31885,
+            9
+        ]
     },
     {
         "name": "Jimmy",
@@ -9190,7 +12676,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Top_of_the_City_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32857,31382,6:2",
+        "coords": [
+            32857,
+            31382,
+            6
+        ]
     },
     {
         "name": "John",
@@ -9204,6 +12696,12 @@
         "quests": [],
         "dialogues": [
             "Souvenirs! Shovels! Treasure maps! Noble watches! Tools! All here for great prices!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32138,32903,7:2",
+        "coords": [
+            32138,
+            32903,
+            7
         ]
     },
     {
@@ -9221,7 +12719,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Adventures_of_Galthen_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32442,32486,3:2",
+        "coords": [
+            32442,
+            32486,
+            3
+        ]
     },
     {
         "name": "John the Carpenter",
@@ -9233,7 +12737,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.182-126.217-8-2-1-1",
         "version": "12.70.10953",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32438,32472,8:2",
+        "coords": [
+            32438,
+            32472,
+            8
+        ]
     },
     {
         "name": "Jondrin",
@@ -9245,7 +12755,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.115-124.140-4-2-1-1",
         "version": "10.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33651,31883,4:2",
+        "coords": [
+            33651,
+            31883,
+            4
+        ]
     },
     {
         "name": "Jorge",
@@ -9264,6 +12780,12 @@
         ],
         "dialogues": [
             "Oh you're not the most communicative kind, are you?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32201,32291,6:2",
+        "coords": [
+            32201,
+            32291,
+            6
         ]
     },
     {
@@ -9276,7 +12798,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.30-124.204-13-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33566,31947,13:2",
+        "coords": [
+            33566,
+            31947,
+            13
+        ]
     },
     {
         "name": "Julian",
@@ -9290,6 +12818,12 @@
         "quests": [],
         "dialogues": [
             "A customer? That's music in my ears!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32883,32075,6:2",
+        "coords": [
+            32883,
+            32075,
+            6
         ]
     },
     {
@@ -9307,7 +12841,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32830,31275,7:2",
+        "coords": [
+            32830,
+            31275,
+            7
+        ]
     },
     {
         "name": "Junkar",
@@ -9327,6 +12867,12 @@
         "dialogues": [
             "So much to do. So many things to be fixed.",
             "Still so much work."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32524,32037,14:2",
+        "coords": [
+            32524,
+            32037,
+            14
         ]
     },
     {
@@ -9339,7 +12885,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.143-127.0-8-2-1-1",
         "version": "11.30.4868",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32911,32511,8:2",
+        "coords": [
+            32911,
+            32511,
+            8
+        ]
     },
     {
         "name": "Kalissa",
@@ -9351,7 +12903,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.217-125.39-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32217,32038,13:2",
+        "coords": [
+            32217,
+            32038,
+            13
+        ]
     },
     {
         "name": "Kallimae",
@@ -9372,6 +12930,12 @@
             "Praised be Bastesh, the Keeper of Wisdom.",
             "Ah, the Hanging Gardens! Always a pleasure to amuse oneself here.",
             "The steppe is dangerous these days - as well as the catacombs."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33935,31482,5:2",
+        "coords": [
+            33935,
+            31482,
+            5
         ]
     },
     {
@@ -9384,7 +12948,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.176-125.108-5-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32944,32107,5:2",
+        "coords": [
+            32944,
+            32107,
+            5
+        ]
     },
     {
         "name": "Karith",
@@ -9401,7 +12971,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32818,31277,5:2",
+        "coords": [
+            32818,
+            31277,
+            5
+        ]
     },
     {
         "name": "Karl",
@@ -9418,7 +12994,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Secret_Service_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32318,31796,8:2",
+        "coords": [
+            32318,
+            31796,
+            8
+        ]
     },
     {
         "name": "Kasmir",
@@ -9435,7 +13017,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33212,32451,1:2",
+        "coords": [
+            33212,
+            32451,
+            1
+        ]
     },
     {
         "name": "Kaumudi",
@@ -9447,7 +13035,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.169-127.252-7-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33705,32763,7:2",
+        "coords": [
+            33705,
+            32763,
+            7
+        ]
     },
     {
         "name": "Kawill",
@@ -9464,7 +13058,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Spark_of_the_Phoenix"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32644,31968,12:2",
+        "coords": [
+            32644,
+            31968,
+            12
+        ]
     },
     {
         "name": "Kaya",
@@ -9479,6 +13079,12 @@
         "dialogues": [
             "Leave your money in the bank during your hunt - trust me, it's safer that way.",
             "It's a wise idea to store your money in your bank account."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33636,31677,8:2",
+        "coords": [
+            33636,
+            31677,
+            8
         ]
     },
     {
@@ -9500,7 +13106,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/To_Appease_the_Mighty_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33231,32388,6:2",
+        "coords": [
+            33231,
+            32388,
+            6
+        ]
     },
     {
         "name": "Kendra",
@@ -9512,7 +13124,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.7-126.9-7-2-1-1",
         "version": "11.03.4246",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32263,32264,7:2",
+        "coords": [
+            32263,
+            32264,
+            7
+        ]
     },
     {
         "name": "Kepar",
@@ -9526,6 +13144,12 @@
         "quests": [],
         "dialogues": [
             "Always on guard."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32193,32296,6:2",
+        "coords": [
+            32193,
+            32296,
+            6
         ]
     },
     {
@@ -9538,7 +13162,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.109-126.222-2-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32365,32477,2:2",
+        "coords": [
+            32365,
+            32477,
+            2
+        ]
     },
     {
         "name": "Kesar's Valet",
@@ -9550,7 +13180,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.110-126.220-2-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32366,32475,2:2",
+        "coords": [
+            32366,
+            32475,
+            2
+        ]
     },
     {
         "name": "Kevin",
@@ -9567,7 +13203,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Postman_Missions_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32569,32017,6:2",
+        "coords": [
+            32569,
+            32017,
+            6
+        ]
     },
     {
         "name": "Khanna",
@@ -9582,6 +13224,12 @@
         "dialogues": [
             "If you need runes, this is the market stall for you!",
             "I'm selling magic equipment. Come and have a look."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33916,31505,7:2",
+        "coords": [
+            33916,
+            31505,
+            7
         ]
     },
     {
@@ -9594,7 +13242,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.75-122.169-8-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32587,31400,8:2",
+        "coords": [
+            32587,
+            31400,
+            8
+        ]
     },
     {
         "name": "King Tibianus",
@@ -9619,7 +13273,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Noodles_is_Gone_Mini_World_Change"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32311,32170,6:2",
+        "coords": [
+            32311,
+            32170,
+            6
+        ]
     },
     {
         "name": "Kito",
@@ -9631,7 +13291,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.229-122.232-2-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32997,31463,2:2",
+        "coords": [
+            32997,
+            31463,
+            2
+        ]
     },
     {
         "name": "Kizar",
@@ -9646,6 +13312,12 @@
         "dialogues": [
             "Perhaps I should prepare a bath for him.",
             "The First Dragon is somewhat restless today."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33596,30988,14:2",
+        "coords": [
+            33596,
+            30988,
+            14
         ]
     },
     {
@@ -9658,7 +13330,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.212-121.152-7-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32212,31127,7:2",
+        "coords": [
+            32212,
+            31127,
+            7
+        ]
     },
     {
         "name": "Klaus",
@@ -9679,7 +13357,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Treasure_Hunt_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#31979,32826,2:2",
+        "coords": [
+            31979,
+            32826,
+            2
+        ]
     },
     {
         "name": "Klesar",
@@ -9691,7 +13375,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.6-124.203-14-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33542,31946,14:2",
+        "coords": [
+            33542,
+            31946,
+            14
+        ]
     },
     {
         "name": "Klom Stonecutter",
@@ -9713,6 +13403,12 @@
             "We need more volunteers!",
             "And they call this 'deep'...",
             "Preparation is paramount."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33776,32202,14:2",
+        "coords": [
+            33776,
+            32202,
+            14
         ]
     },
     {
@@ -9730,6 +13426,12 @@
             "Strength and courage!",
             "Keep your armor shiny and your blade clean!",
             "All young aspiring adventurers interested in knighthood come here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32088,31988,7:2",
+        "coords": [
+            32088,
+            31988,
+            7
         ]
     },
     {
@@ -9742,7 +13444,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.18-124.222-13-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33554,31965,13:2",
+        "coords": [
+            33554,
+            31965,
+            13
+        ]
     },
     {
         "name": "Kroox",
@@ -9754,7 +13462,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.138-124.143-9-2-1-1",
         "version": "6.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32650,31886,9:2",
+        "coords": [
+            32650,
+            31886,
+            9
+        ]
     },
     {
         "name": "Kulag, The Guard",
@@ -9771,7 +13485,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Inquisition_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32287,32263,7:2",
+        "coords": [
+            32287,
+            32263,
+            7
+        ]
     },
     {
         "name": "Lailene",
@@ -9783,7 +13503,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.2-124.101-4-2-1-1",
         "version": "8.20",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33282,31844,4:2",
+        "coords": [
+            33282,
+            31844,
+            4
+        ]
     },
     {
         "name": "Lardoc Bashsmite",
@@ -9804,6 +13530,12 @@
             "ATTENTION, RECRUITS!",
             "If I catch anyone lingering about and shirking responsibility it's latrine duty FOR A WEEK!",
             "WHY ARE YOU LEAVING YOUR POST?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33838,32122,14:2",
+        "coords": [
+            33838,
+            32122,
+            14
         ]
     },
     {
@@ -9820,6 +13552,12 @@
             "What an interesting speck of land. I have to write down all this in my essay.",
             "I should provide more cookies for the ogres. They're looking at me so hungrily.",
             "Hm, guess I haven't found all new plants in this secluded part of the world yet."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33658,31662,7:2",
+        "coords": [
+            33658,
+            31662,
+            7
         ]
     },
     {
@@ -9837,7 +13575,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Repenters_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32778,31599,11:2",
+        "coords": [
+            32778,
+            31599,
+            11
+        ]
     },
     {
         "name": "Larry",
@@ -9853,6 +13597,12 @@
             "Krahhh!",
             "Keelhaul! Keelhaul!",
             "Gold! Gems!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32268,32811,11:2",
+        "coords": [
+            32268,
+            32811,
+            11
         ]
     },
     {
@@ -9865,7 +13615,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.147-123.197-7-2-1-1",
         "version": "10.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32659,31684,7:2",
+        "coords": [
+            32659,
+            31684,
+            7
+        ]
     },
     {
         "name": "Lazaran",
@@ -9886,7 +13642,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32995,31470,3:2",
+        "coords": [
+            32995,
+            31470,
+            3
+        ]
     },
     {
         "name": "Lea",
@@ -9898,7 +13660,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.92-124.84-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32348,31827,6:2",
+        "coords": [
+            32348,
+            31827,
+            6
+        ]
     },
     {
         "name": "Lector",
@@ -9910,7 +13678,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.95-124.51-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32351,31794,7:2",
+        "coords": [
+            32351,
+            31794,
+            7
+        ]
     },
     {
         "name": "Lee'Delle",
@@ -9927,6 +13701,12 @@
             "Buy and sell everything you want here!",
             "No need to run from shop to shop, my place is all that's needed!",
             "Special offers for premium customers!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32024,32195,7:2",
+        "coords": [
+            32024,
+            32195,
+            7
         ]
     },
     {
@@ -9944,7 +13724,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32883,32081,5:2",
+        "coords": [
+            32883,
+            32081,
+            5
+        ]
     },
     {
         "name": "Legola",
@@ -9958,6 +13744,12 @@
         "quests": [],
         "dialogues": [
             "Teaching paladin spells! Just come to me!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32298,31783,7:2",
+        "coords": [
+            32298,
+            31783,
+            7
         ]
     },
     {
@@ -9975,7 +13767,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Adventures_of_Galthen_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32406,32470,6:2",
+        "coords": [
+            32406,
+            32470,
+            6
+        ]
     },
     {
         "name": "Lesser Messenger of Heaven",
@@ -9987,7 +13785,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.165-123.154-7-2-1-1",
         "version": "10.94",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33189,31641,7:2",
+        "coords": [
+            33189,
+            31641,
+            7
+        ]
     },
     {
         "name": "Liane",
@@ -10004,6 +13808,12 @@
             "Hey, send a letter to your friend now and then. Keep in touch, you know.",
             "If you need help with letters or parcels, just ask me. I can explain everything.",
             "No, no, no, there IS no parcel bug, I'm telling you!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32332,31785,7:2",
+        "coords": [
+            32332,
+            31785,
+            7
         ]
     },
     {
@@ -10016,7 +13826,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.153-125.76-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32921,32075,6:2",
+        "coords": [
+            32921,
+            32075,
+            6
+        ]
     },
     {
         "name": "Lily",
@@ -10035,6 +13851,12 @@
             "Anyone got some cookies for me?",
             "Do you need help? Just ask me about anything you'd like to know!",
             "I'm buying all of your blueberries for my famous blueberry juice!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32068,32224,7:2",
+        "coords": [
+            32068,
+            32224,
+            7
         ]
     },
     {
@@ -10052,7 +13874,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32815,31245,7:2",
+        "coords": [
+            32815,
+            31245,
+            7
+        ]
     },
     {
         "name": "Livielle",
@@ -10066,6 +13894,12 @@
         "quests": [],
         "dialogues": [
             "Ah, salut! Come 'ere and 'ave some of my delicious fruits!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32982,32035,6:2",
+        "coords": [
+            32982,
+            32035,
+            6
         ]
     },
     {
@@ -10078,7 +13912,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.237-121.183-7-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33261,31158,7:2",
+        "coords": [
+            33261,
+            31158,
+            7
+        ]
     },
     {
         "name": "Lizard Tunnel Guard",
@@ -10095,7 +13935,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33379,31106,8:2",
+        "coords": [
+            33379,
+            31106,
+            8
+        ]
     },
     {
         "name": "Llathriel",
@@ -10107,7 +13953,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.198-123.110-5-2-1-1",
         "version": "8.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32710,31597,5:2",
+        "coords": [
+            32710,
+            31597,
+            5
+        ]
     },
     {
         "name": "Lokur",
@@ -10124,6 +13976,12 @@
             "Also selling weekly tickets for the ore wagon service!",
             "Welcome to the post and bank office!",
             "If you need help with letters or parcels, just ask me. I can explain everything."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32648,31904,8:2",
+        "coords": [
+            32648,
+            31904,
+            8
         ]
     },
     {
@@ -10136,7 +13994,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.186-121.48-7-2-1-1",
         "version": "11.03.4246",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33466,31023,7:2",
+        "coords": [
+            33466,
+            31023,
+            7
+        ]
     },
     {
         "name": "Lorbas",
@@ -10153,7 +14017,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32695,32309,7:2",
+        "coords": [
+            32695,
+            32309,
+            7
+        ]
     },
     {
         "name": "Lorek",
@@ -10165,7 +14035,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.167-128.7-7-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32679,32774,7:2",
+        "coords": [
+            32679,
+            32774,
+            7
+        ]
     },
     {
         "name": "Lorenzo",
@@ -10180,6 +14056,12 @@
         "dialogues": [
             "Drome fighters! You can trade your hard earned drome points here!",
             "Fighters from the old arena still visit me to exchange their hard earned badges! Earned in blood that is... mostly."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32297,32202,11:2",
+        "coords": [
+            32297,
+            32202,
+            11
         ]
     },
     {
@@ -10192,7 +14074,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.129-125.131-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32385,32130,7:2",
+        "coords": [
+            32385,
+            32130,
+            7
+        ]
     },
     {
         "name": "Lorietta",
@@ -10204,7 +14092,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.19-122.45-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32787,31276,7:2",
+        "coords": [
+            32787,
+            31276,
+            7
+        ]
     },
     {
         "name": "Lost Traveler",
@@ -10221,7 +14115,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Tibia%27s_25th_Anniversary#Scavenger_Hunt"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32356,32160,7:2",
+        "coords": [
+            32356,
+            32160,
+            7
+        ]
     },
     {
         "name": "Lothar",
@@ -10235,6 +14135,12 @@
         "quests": [],
         "dialogues": [
             "I enjoy the peace and solitude out here. You're welcome to be my guest as long as you behave in a quiet and tolerable manner."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32225,31703,7:2",
+        "coords": [
+            32225,
+            31703,
+            7
         ]
     },
     {
@@ -10251,6 +14157,12 @@
             "BEWARE! Beware of that hole!",
             "STAY AWAY FROM THAT HOLE!",
             "What are you doing here?? Get away from that hole!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32015,32196,7:2",
+        "coords": [
+            32015,
+            32196,
+            7
         ]
     },
     {
@@ -10265,6 +14177,12 @@
         "quests": [],
         "dialogues": [
             "Stop by and rest a while, tired adventurer! Have a look at my wares!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32488,32118,7:2",
+        "coords": [
+            32488,
+            32118,
+            7
         ]
     },
     {
@@ -10287,6 +14205,12 @@
             "It's the time of the year where we all need some light.",
             "Argh... curse those silly dwarves!",
             "I think I've seen your face before."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32892,31093,7:2",
+        "coords": [
+            32892,
+            31093,
+            7
         ]
     },
     {
@@ -10308,7 +14232,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wizard_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32389,32117,8:2",
+        "coords": [
+            32389,
+            32117,
+            8
+        ]
     },
     {
         "name": "Lukosch",
@@ -10322,6 +14252,12 @@
         "quests": [],
         "dialogues": [
             "Lorry tickets! A thrilling ride deep into the mountain!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32618,31946,7:2",
+        "coords": [
+            32618,
+            31946,
+            7
         ]
     },
     {
@@ -10334,7 +14270,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.230-124.96-5-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33254,31839,5:2",
+        "coords": [
+            33254,
+            31839,
+            5
+        ]
     },
     {
         "name": "Lunch",
@@ -10348,6 +14290,12 @@
         "quests": [],
         "dialogues": [
             "La La Laaa Laaahh!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32525,32029,14:2",
+        "coords": [
+            32525,
+            32029,
+            14
         ]
     },
     {
@@ -10360,7 +14308,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.47-126.11-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32303,32266,6:2",
+        "coords": [
+            32303,
+            32266,
+            6
+        ]
     },
     {
         "name": "Lurik",
@@ -10381,7 +14335,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Explorer_Society"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32320,31135,7:2",
+        "coords": [
+            32320,
+            31135,
+            7
+        ]
     },
     {
         "name": "Lynda",
@@ -10406,7 +14366,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Summoner_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32333,32199,7:2",
+        "coords": [
+            32333,
+            32199,
+            7
+        ]
     },
     {
         "name": "Lyonel",
@@ -10420,6 +14386,12 @@
         "quests": [],
         "dialogues": [
             "Relax in my tavern after an exhausting hunt!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32297,32830,7:2",
+        "coords": [
+            32297,
+            32830,
+            7
         ]
     },
     {
@@ -10437,7 +14409,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32732,31630,7:2",
+        "coords": [
+            32732,
+            31630,
+            7
+        ]
     },
     {
         "name": "Maelyrra",
@@ -10458,6 +14436,12 @@
             "Annoying nightmarish creatures!",
             "Our siblings are tainted. Bewail them!",
             "This is the homestead of every pleasant dream."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33484,32236,7:2",
+        "coords": [
+            33484,
+            32236,
+            7
         ]
     },
     {
@@ -10479,6 +14463,12 @@
             "Not enough purple nightshade ... not enough liquid silver. *sigh*",
             "You think the full moon is a romantic affair? Think again!",
             "This place isn't safe. You should leave this island."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33331,31685,7:2",
+        "coords": [
+            33331,
+            31685,
+            7
         ]
     },
     {
@@ -10491,7 +14481,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.226-123.11-3-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32994,31498,3:2",
+        "coords": [
+            32994,
+            31498,
+            3
+        ]
     },
     {
         "name": "Malech",
@@ -10503,7 +14499,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.93-124.195-10-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32605,31938,10:2",
+        "coords": [
+            32605,
+            31938,
+            10
+        ]
     },
     {
         "name": "Malor",
@@ -10524,7 +14526,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Killing_in_the_Name_of..._Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33044,32620,1:2",
+        "coords": [
+            33044,
+            32620,
+            1
+        ]
     },
     {
         "name": "Malunga",
@@ -10538,6 +14546,12 @@
         "quests": [],
         "dialogues": [
             "<mumble>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32347,32807,5:2",
+        "coords": [
+            32347,
+            32807,
+            5
         ]
     },
     {
@@ -10550,7 +14564,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.214-125.70-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32214,32069,13:2",
+        "coords": [
+            32214,
+            32069,
+            13
+        ]
     },
     {
         "name": "Marcus",
@@ -10562,7 +14582,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.60-128.94-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32316,32861,7:2",
+        "coords": [
+            32316,
+            32861,
+            7
+        ]
     },
     {
         "name": "Maria",
@@ -10576,6 +14602,12 @@
         "quests": [],
         "dialogues": [
             "Hello, hello! Put your feet up and relax in the Hard Rock Tavern."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32912,32081,9:2",
+        "coords": [
+            32912,
+            32081,
+            9
         ]
     },
     {
@@ -10600,6 +14632,12 @@
         "dialogues": [
             "You wouldn't keep a pretty lady like me waiting, would you?",
             "Hello, come and entertain me for a while!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32329,32527,7:2",
+        "coords": [
+            32329,
+            32527,
+            7
         ]
     },
     {
@@ -10617,7 +14655,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32649,31292,6:2",
+        "coords": [
+            32649,
+            31292,
+            6
+        ]
     },
     {
         "name": "Maritima",
@@ -10634,7 +14678,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32905,31166,13:2",
+        "coords": [
+            32905,
+            31166,
+            13
+        ]
     },
     {
         "name": "Markwin",
@@ -10655,7 +14705,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32418,32146,15:2",
+        "coords": [
+            32418,
+            32146,
+            15
+        ]
     },
     {
         "name": "Marlene",
@@ -10667,7 +14723,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.227-123.136-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32483,31623,7:2",
+        "coords": [
+            32483,
+            31623,
+            7
+        ]
     },
     {
         "name": "Maro",
@@ -10681,6 +14743,12 @@
         "quests": [],
         "dialogues": [
             "Hm."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33622,31882,6:2",
+        "coords": [
+            33622,
+            31882,
+            6
         ]
     },
     {
@@ -10693,7 +14761,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.188-125.213-8-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32444,32212,8:2",
+        "coords": [
+            32444,
+            32212,
+            8
+        ]
     },
     {
         "name": "Marvin",
@@ -10714,6 +14788,12 @@
             "The citizens of Rathleton voted for Bullwark/Glooth Fairy/Lisa.",
             "The citizens of Rathleton voted for the shortcut back from the catacombs/fungi/minotaurs.",
             "The citizens of Rathleton voted for the golems/minotaurs/wrath of evil in the dungeon."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33662,31877,5:2",
+        "coords": [
+            33662,
+            31877,
+            5
         ]
     },
     {
@@ -10731,7 +14811,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Marid_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32634,31888,9:2",
+        "coords": [
+            32634,
+            31888,
+            9
+        ]
     },
     {
         "name": "Maun",
@@ -10743,7 +14829,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.243-127.51-7-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33523,32562,7:2",
+        "coords": [
+            33523,
+            32562,
+            7
+        ]
     },
     {
         "name": "Mazarius",
@@ -10760,7 +14852,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Ferumbras%27_Ascension_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33275,32391,8:2",
+        "coords": [
+            33275,
+            32391,
+            8
+        ]
     },
     {
         "name": "Mehkesh",
@@ -10774,6 +14872,12 @@
         "quests": [],
         "dialogues": [
             "Potions brewed by the leading alchemists of the land!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33130,32810,5:2",
+        "coords": [
+            33130,
+            32810,
+            5
         ]
     },
     {
@@ -10795,7 +14899,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Djinn_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33192,32819,7:2",
+        "coords": [
+            33192,
+            32819,
+            7
+        ]
     },
     {
         "name": "Melfar",
@@ -10814,6 +14924,12 @@
         ],
         "dialogues": [
             "This weather is killing me. If I only had enough money to retire."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32523,31965,7:2",
+        "coords": [
+            32523,
+            31965,
+            7
         ]
     },
     {
@@ -10826,7 +14942,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.215-123.51-1-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32983,31538,1:2",
+        "coords": [
+            32983,
+            31538,
+            1
+        ]
     },
     {
         "name": "Memech",
@@ -10840,6 +14962,12 @@
         "quests": [],
         "dialogues": [
             "Selling weapons and armors to protect mortal souls."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33135,32809,6:2",
+        "coords": [
+            33135,
+            32809,
+            6
         ]
     },
     {
@@ -10854,6 +14982,12 @@
         "quests": [],
         "dialogues": [
             "Grrrr."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32807,31246,7:2",
+        "coords": [
+            32807,
+            31246,
+            7
         ]
     },
     {
@@ -10871,7 +15005,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Tutorial"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32076,31845,13:2",
+        "coords": [
+            32076,
+            31845,
+            13
+        ]
     },
     {
         "name": "Meraya",
@@ -10883,7 +15023,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.188-128.207-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32188,32974,7:2",
+        "coords": [
+            32188,
+            32974,
+            7
+        ]
     },
     {
         "name": "Messenger of Heaven",
@@ -10900,7 +15046,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Heart_of_Destruction_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33172,32633,7:2",
+        "coords": [
+            33172,
+            32633,
+            7
+        ]
     },
     {
         "name": "Messenger of Santa",
@@ -10918,7 +15070,9 @@
             "Three hundred Banor action figures... check!",
             "Fourhundred  sugar canes, wrapped up and bundled... check!",
             "Five thousand pieces of marzipan... <gulp>, erm, four thousand nine hundred ninety-nine pieces of marzipan - check..."
-        ]
+        ],
+        "tibiamap": "",
+        "coords": []
     },
     {
         "name": "Miles, The Guard",
@@ -10935,7 +15089,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Inquisition_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32431,32171,5:2",
+        "coords": [
+            32431,
+            32171,
+            5
+        ]
     },
     {
         "name": "Milos",
@@ -10962,6 +15122,12 @@
         ],
         "dialogues": [
             "What a fascinating idea!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33259,31825,3:2",
+        "coords": [
+            33259,
+            31825,
+            3
         ]
     },
     {
@@ -10979,7 +15145,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Bewitched"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32743,31970,12:2",
+        "coords": [
+            32743,
+            31970,
+            12
+        ]
     },
     {
         "name": "Mirabell",
@@ -10998,6 +15170,12 @@
         ],
         "dialogues": [
             "The Horn of Plenty is always open for tired adventurers."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33174,31800,6:2",
+        "coords": [
+            33174,
+            31800,
+            6
         ]
     },
     {
@@ -11015,7 +15193,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Oriental_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33238,32482,7:2",
+        "coords": [
+            33238,
+            32482,
+            7
+        ]
     },
     {
         "name": "Moe",
@@ -11036,6 +15220,12 @@
             "The menu of the day sounds delicious!",
             "The last visit to the theatre was quite rewarding.",
             "Such a beautiful and wealthy city - with so many opportunities ..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33910,31495,5:2",
+        "coords": [
+            33910,
+            31495,
+            5
         ]
     },
     {
@@ -11057,6 +15247,12 @@
             "Zzzz... tea... I'll make a cup of tea...zzzz...",
             "Zzzz... tea... Oh... tea...chrrr...zzz...",
             "Zzzz.... chrzzz...."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33631,32342,6:2",
+        "coords": [
+            33631,
+            32342,
+            6
         ]
     },
     {
@@ -11076,6 +15272,12 @@
             "Now where did Alaistar put the wood for the new wands?",
             "Hmmm.. Maybe those crushed gems caused the strange side effect?",
             "Wands and rods, the true magician's weapons of choice!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33618,31883,5:2",
+        "coords": [
+            33618,
+            31883,
+            5
         ]
     },
     {
@@ -11105,7 +15307,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Meriana_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32323,32598,7:2",
+        "coords": [
+            32323,
+            32598,
+            7
+        ]
     },
     {
         "name": "Morpel",
@@ -11117,7 +15325,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.54-122.7-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32822,31238,7:2",
+        "coords": [
+            32822,
+            31238,
+            7
+        ]
     },
     {
         "name": "Mortimer",
@@ -11134,7 +15348,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Explorer_Society_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32499,31625,7:2",
+        "coords": [
+            32499,
+            31625,
+            7
+        ]
     },
     {
         "name": "Mortis",
@@ -11146,7 +15366,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.0-126.247-5-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33536,32502,5:2",
+        "coords": [
+            33536,
+            32502,
+            5
+        ]
     },
     {
         "name": "Morun",
@@ -11158,7 +15384,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.216-126.137-6-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33240,32392,6:2",
+        "coords": [
+            33240,
+            32392,
+            6
+        ]
     },
     {
         "name": "Mother Of Jack",
@@ -11180,6 +15412,12 @@
             "Oh dear, I can't find anything in here!",
             "There is still some dust on the drawer over there. What where you thinking, Jane?",
             "Jane!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33274,31755,6:2",
+        "coords": [
+            33274,
+            31755,
+            6
         ]
     },
     {
@@ -11203,6 +15441,12 @@
             "<grumble> Maybe I should rearrange some warm currents to get rid of this horrible fog.",
             "My ring! My wedding ring! <sigh>",
             "WHAT WAS THAT? ... Oh. It's only a shadow in the water. - A SHADOW IN THE WATER? HELP! HELP!! THEY'RE COMING AFTER ME!!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33548,31863,7:2",
+        "coords": [
+            33548,
+            31863,
+            7
         ]
     },
     {
@@ -11229,6 +15473,12 @@
             "<sigh> The Adventurers' Guild really should have equipped me with more man power. Who's to keep all those monsters in check?",
             "Hmm? I'm a very busy man. Look into your quest log to keep track of your progress in a quest, please.",
             "So much to investigate, so little time..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32070,31900,4:2",
+        "coords": [
+            32070,
+            31900,
+            4
         ]
     },
     {
@@ -11248,6 +15498,12 @@
         ],
         "dialogues": [
             "I'll make them an offer they can't refuse."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32772,31358,6:2",
+        "coords": [
+            32772,
+            31358,
+            6
         ]
     },
     {
@@ -11260,7 +15516,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.196-126.160-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33220,32415,7:2",
+        "coords": [
+            33220,
+            32415,
+            7
+        ]
     },
     {
         "name": "Mugruu",
@@ -11276,6 +15538,12 @@
             "Come! Look!",
             "Buying nice things!",
             "Mugruu buys glittering stones and other pretty things."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33635,31676,7:2",
+        "coords": [
+            33635,
+            31676,
+            7
         ]
     },
     {
@@ -11297,7 +15565,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Arito%27s_Task_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33279,32525,9:2",
+        "coords": [
+            33279,
+            32525,
+            9
+        ]
     },
     {
         "name": "Muriel",
@@ -11318,6 +15592,12 @@
             "Did you hear about the missing member of the Explorer Society?",
             "There are rumours about a mysterious inscription underneath Thais.",
             "The wisdom of spellcasting is the source of power."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32296,32262,7:2",
+        "coords": [
+            32296,
+            32262,
+            7
         ]
     },
     {
@@ -11330,7 +15610,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.245-123.6-10-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33013,31493,10:2",
+        "coords": [
+            33013,
+            31493,
+            10
+        ]
     },
     {
         "name": "Mutated Assistant",
@@ -11342,7 +15628,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.17-127.70-9-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33809,32581,9:2",
+        "coords": [
+            33809,
+            32581,
+            9
+        ]
     },
     {
         "name": "Muzir",
@@ -11354,7 +15646,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.197-126.133-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33221,32388,7:2",
+        "coords": [
+            33221,
+            32388,
+            7
+        ]
     },
     {
         "name": "Myra",
@@ -11366,7 +15664,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.68-127.239-6-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32580,32750,6:2",
+        "coords": [
+            32580,
+            32750,
+            6
+        ]
     },
     {
         "name": "Mysterious Device",
@@ -11383,7 +15687,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32815,32901,13:2",
+        "coords": [
+            32815,
+            32901,
+            13
+        ]
     },
     {
         "name": "Mysterious Ornate Chest",
@@ -11400,7 +15710,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32673,31600,8:2",
+        "coords": [
+            32673,
+            31600,
+            8
+        ]
     },
     {
         "name": "Myzzi",
@@ -11419,6 +15735,12 @@
         ],
         "dialogues": [
             "I have to find some heroes. Find, find, find!!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33275,31700,7:2",
+        "coords": [
+            33275,
+            31700,
+            7
         ]
     },
     {
@@ -11436,7 +15758,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Primal_Ordeal_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33909,32761,7:2",
+        "coords": [
+            33909,
+            32761,
+            7
+        ]
     },
     {
         "name": "Nah'Bob",
@@ -11453,7 +15781,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest/Spoiler#Mission_10_-_A_Sweet_Surprise"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33104,32519,2:2",
+        "coords": [
+            33104,
+            32519,
+            2
+        ]
     },
     {
         "name": "Naji",
@@ -11467,6 +15801,12 @@
         "quests": [],
         "dialogues": [
             "It's a wise idea to store your money in your bank account."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32342,32228,7:2",
+        "coords": [
+            32342,
+            32228,
+            7
         ]
     },
     {
@@ -11479,7 +15819,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.223-123.8-3-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32991,31495,3:2",
+        "coords": [
+            32991,
+            31495,
+            3
+        ]
     },
     {
         "name": "Narsai",
@@ -11495,6 +15841,12 @@
             "I can't bring down a crocodile myself.",
             "Alyxo has the most beautiful voice, that's for sure.",
             "I don't want to disappoint Kallimae."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33912,31528,7:2",
+        "coords": [
+            33912,
+            31528,
+            7
         ]
     },
     {
@@ -11511,6 +15863,12 @@
             "Green is the colour of life.",
             "Preserving nature in its purest form.",
             "Leaves, bushes, meadows... green is my colour!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32953,32053,6:2",
+        "coords": [
+            32953,
+            32053,
+            6
         ]
     },
     {
@@ -11536,7 +15894,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Achievement"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33640,31376,9:2",
+        "coords": [
+            33640,
+            31376,
+            9
+        ]
     },
     {
         "name": "Ned Nobel",
@@ -11551,6 +15915,12 @@
         "dialogues": [
             "A prosperous new year!",
             "Rockits for everyone! Come and have some fun!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32652,31699,7:2",
+        "coords": [
+            32652,
+            31699,
+            7
         ]
     },
     {
@@ -11573,6 +15943,12 @@
             "Enter our tents and choose your destiny!",
             "Close quarter combat, swords and shields! Have at it!",
             "Rookies! Initiates! Friends! Lend me your ears!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32076,32026,7:2",
+        "coords": [
+            32076,
+            32026,
+            7
         ]
     },
     {
@@ -11587,6 +15963,12 @@
         "quests": [],
         "dialogues": [
             "The right tools are the secret of a green thumb."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32883,32085,6:2",
+        "coords": [
+            32883,
+            32085,
+            6
         ]
     },
     {
@@ -11602,6 +15984,12 @@
         "dialogues": [
             "Welcome to the post office!",
             "Also selling runes, potions and magical equipment!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32308,31133,7:2",
+        "coords": [
+            32308,
+            31133,
+            7
         ]
     },
     {
@@ -11635,7 +16023,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Key_4037"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32615,32107,10:2",
+        "coords": [
+            32615,
+            32107,
+            10
+        ]
     },
     {
         "name": "Nezil",
@@ -11649,6 +16043,12 @@
         "quests": [],
         "dialogues": [
             "Equipment and general goods here at our shop!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32661,31911,9:2",
+        "coords": [
+            32661,
+            31911,
+            9
         ]
     },
     {
@@ -11671,6 +16071,12 @@
             "Making grub as fast as can!",
             "Poor goblin! Poor goblin!",
             "<sigh>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33657,31650,7:2",
+        "coords": [
+            33657,
+            31650,
+            7
         ]
     },
     {
@@ -11691,6 +16097,12 @@
         "dialogues": [
             "The newest items from Venore! Finest tapestries, lamps and clocks!",
             "Hand-crafted timeless design from the very best in Rathleton!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33640,31897,5:2",
+        "coords": [
+            33640,
+            31897,
+            5
         ]
     },
     {
@@ -11703,7 +16115,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.235-123.187-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32235,31674,7:2",
+        "coords": [
+            32235,
+            31674,
+            7
+        ]
     },
     {
         "name": "Nienna",
@@ -11717,6 +16135,12 @@
         "quests": [],
         "dialogues": [
             "Get your flowers and that special something for your loved one!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32074,32446,7:2",
+        "coords": [
+            32074,
+            32446,
+            7
         ]
     },
     {
@@ -11729,7 +16153,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.185-128.2-3-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33721,32769,3:2",
+        "coords": [
+            33721,
+            32769,
+            3
+        ]
     },
     {
         "name": "Nilavarna",
@@ -11741,7 +16171,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.194-128.57-6-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33730,32824,6:2",
+        "coords": [
+            33730,
+            32824,
+            6
+        ]
     },
     {
         "name": "Nilsor",
@@ -11758,7 +16194,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Ice_Islands_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32329,31043,7:2",
+        "coords": [
+            32329,
+            31043,
+            7
+        ]
     },
     {
         "name": "Nina",
@@ -11770,7 +16212,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.156-121.224-8-2-1-1",
         "version": "9.86",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33180,31199,8:2",
+        "coords": [
+            33180,
+            31199,
+            8
+        ]
     },
     {
         "name": "Ninev",
@@ -11791,6 +16239,12 @@
             "She Who Knows protects our dreams.",
             "Praised be Bastesh, the Mistress of the Sea!",
             "May Bastesh grant you foresight and wisdom."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33868,31526,7:2",
+        "coords": [
+            33868,
+            31526,
+            7
         ]
     },
     {
@@ -11806,6 +16260,12 @@
         "dialogues": [
             "Welcome to the post office!",
             "If you need help with letters or parcels, just ask me. I can explain everything."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33904,31497,7:2",
+        "coords": [
+            33904,
+            31497,
+            7
         ]
     },
     {
@@ -11821,6 +16281,12 @@
         "dialogues": [
             "I'm selling magic equipment. Come and have a look.",
             "If you need runes, this is the market stall for you!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33778,32836,6:2",
+        "coords": [
+            33778,
+            32836,
+            6
         ]
     },
     {
@@ -11838,7 +16304,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32607,31489,14:2",
+        "coords": [
+            32607,
+            31489,
+            14
+        ]
     },
     {
         "name": "Nomad",
@@ -11850,7 +16322,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=124.196-122.73-6-2-1-1",
         "version": "11.30.4868",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#31940,31304,6:2",
+        "coords": [
+            31940,
+            31304,
+            6
+        ]
     },
     {
         "name": "Noodles",
@@ -11877,6 +16355,12 @@
             "<sniff>",
             "Woof! Woof!",
             "Wooof!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32312,32173,6:2",
+        "coords": [
+            32312,
+            32173,
+            6
         ]
     },
     {
@@ -11898,6 +16382,12 @@
             "Another one sneaking around... what has a man in a cave to do to get some peace and quiet?!",
             "Hm... intruder? Hm? No, no - just my imagination.",
             "What am I doing here..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32502,32337,8:2",
+        "coords": [
+            32502,
+            32337,
+            8
         ]
     },
     {
@@ -11917,6 +16407,12 @@
         ],
         "dialogues": [
             "If you're caught or killed, I'll deny that I have known you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32001,31442,7:2",
+        "coords": [
+            32001,
+            31442,
+            7
         ]
     },
     {
@@ -11931,6 +16427,12 @@
         "quests": [],
         "dialogues": [
             "Wonderful and stylish clothes! Come and buy!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32953,32102,6:2",
+        "coords": [
+            32953,
+            32102,
+            6
         ]
     },
     {
@@ -11943,7 +16445,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.90-126.107-6-2-1-1",
         "version": "7.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32346,32362,6:2",
+        "coords": [
+            32346,
+            32362,
+            6
+        ]
     },
     {
         "name": "Norma",
@@ -11970,6 +16478,12 @@
             "<sings> ... are a girl's best friieeend...",
             "Sing and dance at my bar! Yeah!",
             "Best place in town! Come to my bar!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32098,32176,7:2",
+        "coords": [
+            32098,
+            32176,
+            7
         ]
     },
     {
@@ -11994,6 +16508,12 @@
             "Oi you! Yes, you! Come on, come on, get movin'! Lose that coffee mug and check on the water wheels!",
             "You! Get your lazy butt up this minute! I don't pay you for starin' 'oles in the air!",
             "You there! D'ya call that work? I call that lazin' around! Now get to choppin' up that timber this instant!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33016,32099,6:2",
+        "coords": [
+            33016,
+            32099,
+            6
         ]
     },
     {
@@ -12006,7 +16526,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.14-124.195-14-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33550,31938,14:2",
+        "coords": [
+            33550,
+            31938,
+            14
+        ]
     },
     {
         "name": "Norris",
@@ -12018,7 +16544,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.225-128.2-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32225,32769,7:2",
+        "coords": [
+            32225,
+            32769,
+            7
+        ]
     },
     {
         "name": "Nurik",
@@ -12035,7 +16567,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32930,32068,8:2",
+        "coords": [
+            32930,
+            32068,
+            8
+        ]
     },
     {
         "name": "Nydala",
@@ -12047,7 +16585,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.71-124.83-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32327,31826,7:2",
+        "coords": [
+            32327,
+            31826,
+            7
+        ]
     },
     {
         "name": "Oberon's Bile",
@@ -12064,7 +16608,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Secret_Library_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33361,31316,9:2",
+        "coords": [
+            33361,
+            31316,
+            9
+        ]
     },
     {
         "name": "Oberon's Hate",
@@ -12081,7 +16631,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Secret_Library_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33367,31316,9:2",
+        "coords": [
+            33367,
+            31316,
+            9
+        ]
     },
     {
         "name": "Oberon's Ire",
@@ -12098,7 +16654,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Secret_Library_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33367,31319,9:2",
+        "coords": [
+            33367,
+            31319,
+            9
+        ]
     },
     {
         "name": "Oberon's Spite",
@@ -12115,7 +16677,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Secret_Library_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33361,31319,9:2",
+        "coords": [
+            33361,
+            31319,
+            9
+        ]
     },
     {
         "name": "Obi",
@@ -12132,6 +16700,12 @@
             "Buy your weapons here!",
             "Selling and buying all sorts of weapons, come and have a look!",
             "Give those monsters a good whipping with my weapons!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32109,32202,7:2",
+        "coords": [
+            32109,
+            32202,
+            7
         ]
     },
     {
@@ -12154,6 +16728,12 @@
             "Yes. I listen, master.",
             "I understand.",
             "Not yet, my brothers. Wait."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33023,32308,10:2",
+        "coords": [
+            33023,
+            32308,
+            10
         ]
     },
     {
@@ -12171,7 +16751,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Shattered_Isles_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32310,32621,4:2",
+        "coords": [
+            32310,
+            32621,
+            4
+        ]
     },
     {
         "name": "Odemara",
@@ -12185,6 +16771,12 @@
         "quests": [],
         "dialogues": [
             "This is a good day for buying gems! Come and see how they sparkle!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33015,32057,6:2",
+        "coords": [
+            33015,
+            32057,
+            6
         ]
     },
     {
@@ -12197,7 +16789,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.19-122.6-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32787,31237,7:2",
+        "coords": [
+            32787,
+            31237,
+            7
+        ]
     },
     {
         "name": "Old Adall",
@@ -12209,7 +16807,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.116-128.4-7-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32628,32771,7:2",
+        "coords": [
+            32628,
+            32771,
+            7
+        ]
     },
     {
         "name": "Old Rock Boy",
@@ -12230,6 +16834,12 @@
             "Come, come here!",
             "Hey! You there! Come near, come!",
             "A traveller on this strange island?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33457,31319,7:2",
+        "coords": [
+            33457,
+            31319,
+            7
         ]
     },
     {
@@ -12253,6 +16863,12 @@
         ],
         "dialogues": [
             "Beware of the undead approaching this temple!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32816,32259,6:2",
+        "coords": [
+            32816,
+            32259,
+            6
         ]
     },
     {
@@ -12265,7 +16881,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.197-125.53-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32197,32052,13:2",
+        "coords": [
+            32197,
+            32052,
+            13
+        ]
     },
     {
         "name": "Oliver",
@@ -12282,7 +16904,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32895,31228,7:2",
+        "coords": [
+            32895,
+            31228,
+            7
+        ]
     },
     {
         "name": "Olrik",
@@ -12299,7 +16927,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Kissing_a_Pig_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32675,31697,7:2",
+        "coords": [
+            32675,
+            31697,
+            7
+        ]
     },
     {
         "name": "Om'Wake Naha",
@@ -12316,7 +16950,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/A_Pirate%27s_Tail_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33744,31331,7:2",
+        "coords": [
+            33744,
+            31331,
+            7
+        ]
     },
     {
         "name": "Omrabas",
@@ -12338,6 +16978,12 @@
             "He will PAY for this... They will ALL pay!",
             "<groan>",
             "If I ever lay hands on him again..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33020,32452,9:2",
+        "coords": [
+            33020,
+            32452,
+            9
         ]
     },
     {
@@ -12350,7 +16996,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.204-126.160-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33228,32415,7:2",
+        "coords": [
+            33228,
+            32415,
+            7
+        ]
     },
     {
         "name": "One-Eyed Joe",
@@ -12367,7 +17019,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Cursed_Crystal_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32026,32885,6:2",
+        "coords": [
+            32026,
+            32885,
+            6
+        ]
     },
     {
         "name": "Onfroi",
@@ -12379,7 +17037,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.172-126.232-5-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32428,32487,5:2",
+        "coords": [
+            32428,
+            32487,
+            5
+        ]
     },
     {
         "name": "Ongulf",
@@ -12399,6 +17063,12 @@
         "dialogues": [
             "Great, another supply ship is due. How is a dwarf supposed to work under these conditions?",
             "Ah, there's nothing like the sound of hammers in the morning."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33025,31539,14:2",
+        "coords": [
+            33025,
+            31539,
+            14
         ]
     },
     {
@@ -12416,7 +17086,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32595,32010,9:2",
+        "coords": [
+            32595,
+            32010,
+            9
+        ]
     },
     {
         "name": "Orc Berserker",
@@ -12428,7 +17104,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.9-122.5-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32777,31236,7:2",
+        "coords": [
+            32777,
+            31236,
+            7
+        ]
     },
     {
         "name": "Oressa",
@@ -12445,6 +17127,12 @@
             "Choose your vocation and explore the Mainland!",
             "Undecided on your vocation? I can help you decide!",
             "Come to me if you need healing!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32064,31891,6:2",
+        "coords": [
+            32064,
+            31891,
+            6
         ]
     },
     {
@@ -12457,7 +17145,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.136-128.42-5-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33160,32809,5:2",
+        "coords": [
+            33160,
+            32809,
+            5
+        ]
     },
     {
         "name": "Orockle",
@@ -12474,7 +17168,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/War_Against_The_Hive_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33448,31308,7:2",
+        "coords": [
+            33448,
+            31308,
+            7
+        ]
     },
     {
         "name": "Ortheus",
@@ -12491,7 +17191,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32879,31084,6:2",
+        "coords": [
+            32879,
+            31084,
+            6
+        ]
     },
     {
         "name": "Oswald",
@@ -12508,7 +17214,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32381,32219,7:2",
+        "coords": [
+            32381,
+            32219,
+            7
+        ]
     },
     {
         "name": "Ottokar",
@@ -12530,6 +17242,12 @@
             "Oh my! Oh my!!",
             "This time things are getting troublesome",
             "All these troubles."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32884,32112,6:2",
+        "coords": [
+            32884,
+            32112,
+            6
         ]
     },
     {
@@ -12546,6 +17264,12 @@
             "I hope their next raid will be less violent.",
             "The inquiries were dangerous, but I hope the benefit will be worth the risks.",
             "My notes are almost complete."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33341,31678,7:2",
+        "coords": [
+            33341,
+            31678,
+            7
         ]
     },
     {
@@ -12558,7 +17282,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.44-124.72-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32300,31815,7:2",
+        "coords": [
+            32300,
+            31815,
+            7
+        ]
     },
     {
         "name": "Paladin Narai",
@@ -12576,6 +17306,12 @@
             "I love the song of a bowstring... twang!",
             "Hey there, come play?",
             "I can tell you everything about paladins!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32109,31988,7:2",
+        "coords": [
+            32109,
+            31988,
+            7
         ]
     },
     {
@@ -12593,7 +17329,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32802,31222,7:2",
+        "coords": [
+            32802,
+            31222,
+            7
+        ]
     },
     {
         "name": "Palomino",
@@ -12605,7 +17347,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.193-125.228-7-2-1-1",
         "version": "9.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32449,32227,7:2",
+        "coords": [
+            32449,
+            32227,
+            7
+        ]
     },
     {
         "name": "Paolo",
@@ -12619,6 +17367,12 @@
         "quests": [],
         "dialogues": [
             "I'm digging here! Go away!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32159,32964,7:2",
+        "coords": [
+            32159,
+            32964,
+            7
         ]
     },
     {
@@ -12636,7 +17390,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Feaster_of_Souls_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32627,32075,7:2",
+        "coords": [
+            32627,
+            32075,
+            7
+        ]
     },
     {
         "name": "Parlan",
@@ -12648,7 +17408,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.185-128.33-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32185,32800,7:2",
+        "coords": [
+            32185,
+            32800,
+            7
+        ]
     },
     {
         "name": "Partos",
@@ -12665,7 +17431,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Efreet_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32323,32279,8:2",
+        "coords": [
+            32323,
+            32279,
+            8
+        ]
     },
     {
         "name": "Pat The Worker",
@@ -12685,6 +17457,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33038,32134,7:2",
+        "coords": [
+            33038,
+            32134,
+            7
         ]
     },
     {
@@ -12701,6 +17479,12 @@
             "I GOT THE POWER!",
             "Join us, go for violet!",
             "Choose the wizard of power to gain power yourself!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32399,32214,7:2",
+        "coords": [
+            32399,
+            32214,
+            7
         ]
     },
     {
@@ -12716,6 +17500,12 @@
         "dialogues": [
             "Deposit your money here in the safety of the Tibian Bank!",
             "Any questions about the functions of your bank account? Feel free to ask me for help!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32117,32187,8:2",
+        "coords": [
+            32117,
+            32187,
+            8
         ]
     },
     {
@@ -12728,7 +17518,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.249-125.237-7-2-1-1",
         "version": "11.40.5409",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33529,32236,7:2",
+        "coords": [
+            33529,
+            32236,
+            7
+        ]
     },
     {
         "name": "Peggy",
@@ -12742,6 +17538,12 @@
         "quests": [],
         "dialogues": [
             "Heya. Furniture on sale! Don't miss the opportunity."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32295,32805,7:2",
+        "coords": [
+            32295,
+            32805,
+            7
         ]
     },
     {
@@ -12759,7 +17561,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Marlin_Trophy"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33287,31955,6:2",
+        "coords": [
+            33287,
+            31955,
+            6
+        ]
     },
     {
         "name": "Penny",
@@ -12771,7 +17579,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.60-124.193-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32316,31936,7:2",
+        "coords": [
+            32316,
+            31936,
+            7
+        ]
     },
     {
         "name": "Perac",
@@ -12785,6 +17599,12 @@
         "quests": [],
         "dialogues": [
             "Everything a paladin needs! Come visit my shop!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32295,31783,7:2",
+        "coords": [
+            32295,
+            31783,
+            7
         ]
     },
     {
@@ -12797,7 +17617,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.73-127.253-6-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32329,32764,6:2",
+        "coords": [
+            32329,
+            32764,
+            6
+        ]
     },
     {
         "name": "Percybald",
@@ -12814,7 +17640,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32380,31785,7:2",
+        "coords": [
+            32380,
+            31785,
+            7
+        ]
     },
     {
         "name": "Peremin",
@@ -12826,7 +17658,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.14-124.219-14-2-1-1",
         "version": "10.70",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33550,31962,14:2",
+        "coords": [
+            33550,
+            31962,
+            14
+        ]
     },
     {
         "name": "Perod",
@@ -12840,6 +17678,12 @@
         "quests": [],
         "dialogues": [
             "Stop by before embarking on your great adventure! Distance weapons and general equipment on sale today!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32634,32739,5:2",
+        "coords": [
+            32634,
+            32739,
+            5
         ]
     },
     {
@@ -12857,7 +17701,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32857,31301,7:2",
+        "coords": [
+            32857,
+            31301,
+            7
+        ]
     },
     {
         "name": "Petros",
@@ -12869,7 +17719,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.9-126.225-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33289,32480,6:2",
+        "coords": [
+            33289,
+            32480,
+            6
+        ]
     },
     {
         "name": "Phillip",
@@ -12881,7 +17737,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.113-124.20-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32369,31763,7:2",
+        "coords": [
+            32369,
+            31763,
+            7
+        ]
     },
     {
         "name": "Pig",
@@ -12898,7 +17760,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Kissing_a_Pig_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32401,32232,7:2",
+        "coords": [
+            32401,
+            32232,
+            7
+        ]
     },
     {
         "name": "Pino",
@@ -12912,6 +17780,12 @@
         "quests": [],
         "dialogues": [
             "Feel the wind in your hair during one of my carpet rides!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33192,31782,3:2",
+        "coords": [
+            33192,
+            31782,
+            3
         ]
     },
     {
@@ -12931,6 +17805,12 @@
         ],
         "dialogues": [
             "I am and never was. The first final piece of a puzzle, put back into its box. But how many boxes are there, how many will there ever be? All of them. There will be all of them."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33938,32496,14:2",
+        "coords": [
+            33938,
+            32496,
+            14
         ]
     },
     {
@@ -12947,6 +17827,12 @@
             "Booooring!",
             "I should rather go and buy some cookies.",
             "That takes ages! I'll return in five levels."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32820,32431,7:2",
+        "coords": [
+            32820,
+            32431,
+            7
         ]
     },
     {
@@ -12963,6 +17849,12 @@
             "I should have stayed on Rookgaard!",
             "That guy already stood there when I was level 1000!",
             "What are you waiting for?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32819,32429,7:2",
+        "coords": [
+            32819,
+            32429,
+            7
         ]
     },
     {
@@ -12979,6 +17871,12 @@
             "<sigh> I guess I'll go swimming.",
             "Does someone have a pack of cards?",
             "Hurry! Hurry!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32819,32432,7:2",
+        "coords": [
+            32819,
+            32432,
+            7
         ]
     },
     {
@@ -12995,6 +17893,12 @@
             "I reached level 999 and all I got was ... Wait, what anyway?",
             "You there! Make your choice!",
             "Hey! No jostling!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32820,32430,7:2",
+        "coords": [
+            32820,
+            32430,
+            7
         ]
     },
     {
@@ -13011,6 +17915,12 @@
             "Should I take this one or that one? I really don't know ...",
             "The helmet also looks great ...",
             "Quiet there in the back! I feel pressurised!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32819,32428,7:2",
+        "coords": [
+            32819,
+            32428,
+            7
         ]
     },
     {
@@ -13027,6 +17937,12 @@
             "Any questions about the functions of your bank account? Feel free to ask me for help!",
             "Deposit your money here in the safety of the Tibian Bank!",
             "Don't get yourself killed out there with pockets full of gold! Deposit your money here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32055,31898,4:2",
+        "coords": [
+            32055,
+            31898,
+            4
         ]
     },
     {
@@ -13050,6 +17966,12 @@
             "ONE, TWO, SHREEEEEE!",
             "Shkip ish shtuuupid!!",
             "Talk to meeeee! CAAAW!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32116,32967,11:2",
+        "coords": [
+            32116,
+            32967,
+            11
         ]
     },
     {
@@ -13062,7 +17984,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.12-123.55-10-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33036,31542,10:2",
+        "coords": [
+            33036,
+            31542,
+            10
+        ]
     },
     {
         "name": "Prezil",
@@ -13074,7 +18002,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.5-123.35-15-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33029,31522,15:2",
+        "coords": [
+            33029,
+            31522,
+            15
+        ]
     },
     {
         "name": "Prisoner",
@@ -13094,6 +18028,12 @@
             "Noooooo!",
             "Please! I beg you to stop!",
             "Take it away! Please!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32315,32272,9:2",
+        "coords": [
+            32315,
+            32272,
+            9
         ]
     },
     {
@@ -13106,7 +18046,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.245-124.106-8-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33269,31849,8:2",
+        "coords": [
+            33269,
+            31849,
+            8
+        ]
     },
     {
         "name": "Pugwah",
@@ -13120,6 +18066,12 @@
         "quests": [],
         "dialogues": [
             "Food! Food! Best food in world from best cook in world!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32809,31250,7:2",
+        "coords": [
+            32809,
+            31250,
+            7
         ]
     },
     {
@@ -13134,6 +18086,12 @@
         "quests": [],
         "dialogues": [
             "Lorry tickets! A thrilling ride deep into the mountain!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32551,31929,7:2",
+        "coords": [
+            32551,
+            31929,
+            7
         ]
     },
     {
@@ -13151,7 +18109,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Phoenix_Egg"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32655,31892,11:2",
+        "coords": [
+            32655,
+            31892,
+            11
+        ]
     },
     {
         "name": "Pyro Peter",
@@ -13167,6 +18131,12 @@
             "Are you even aware of the threat that poses Shadowthorn these days?!",
             "Shadowthorn? It will burn to the ground if we don't act!!",
             "Fire!! Ah... or not."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32948,32094,6:2",
+        "coords": [
+            32948,
+            32094,
+            6
         ]
     },
     {
@@ -13179,7 +18149,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.142-122.126-11-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32654,31357,11:2",
+        "coords": [
+            32654,
+            31357,
+            11
+        ]
     },
     {
         "name": "Pythius the Rotten",
@@ -13196,7 +18172,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32589,31406,15:2",
+        "coords": [
+            32589,
+            31406,
+            15
+        ]
     },
     {
         "name": "Quandons Ghost",
@@ -13213,7 +18195,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Dark_Trails_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33449,32036,8:2",
+        "coords": [
+            33449,
+            32036,
+            8
+        ]
     },
     {
         "name": "Queen Eloise",
@@ -13234,7 +18222,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Lumberjack_Mini_World_Change"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32313,31753,7:2",
+        "coords": [
+            32313,
+            31753,
+            7
+        ]
     },
     {
         "name": "Quentin",
@@ -13251,7 +18245,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32369,32238,7:2",
+        "coords": [
+            32369,
+            32238,
+            7
+        ]
     },
     {
         "name": "Quero",
@@ -13263,7 +18263,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.134-125.220-7-2-1-1",
         "version": "6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32390,32219,7:2",
+        "coords": [
+            32390,
+            32219,
+            7
+        ]
     },
     {
         "name": "Ra'Clette",
@@ -13283,6 +18289,12 @@
         "dialogues": [
             "I will annoy him, too. He he!",
             "Annoying merchant!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33030,32139,5:2",
+        "coords": [
+            33030,
+            32139,
+            5
         ]
     },
     {
@@ -13300,7 +18312,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/An_Interest_In_Botany_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33010,31531,10:2",
+        "coords": [
+            33010,
+            31531,
+            10
+        ]
     },
     {
         "name": "Rachel",
@@ -13312,7 +18330,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.87-124.84-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32343,31827,7:2",
+        "coords": [
+            32343,
+            31827,
+            7
+        ]
     },
     {
         "name": "Raffael",
@@ -13333,6 +18357,12 @@
             "Cheapest offers on the whole island! - Well, the only offers!",
             "Special offers for premium customers!",
             "Don't leave for mainland without stopping by!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32096,31988,7:2",
+        "coords": [
+            32096,
+            31988,
+            7
         ]
     },
     {
@@ -13350,7 +18380,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Goblin_Merchant_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33055,32093,6:2",
+        "coords": [
+            33055,
+            32093,
+            6
+        ]
     },
     {
         "name": "Rahkem",
@@ -13369,6 +18405,12 @@
         ],
         "dialogues": [
             "Please, not so loud, not so loud. Some of us are trying to rest in peace here."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33194,32847,7:2",
+        "coords": [
+            33194,
+            32847,
+            7
         ]
     },
     {
@@ -13387,6 +18429,12 @@
             "Come in and order one of our delicious meals. How about dove on a bed of sauteed broccoli and lemons?",
             "Where is the mango I put here? Has this thieving sibang snitched it?",
             "I'm warning you, Moe. If you have taken this silver spoon ..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33903,31494,7:2",
+        "coords": [
+            33903,
+            31494,
+            7
         ]
     },
     {
@@ -13406,6 +18454,12 @@
         ],
         "dialogues": [
             "Watch your back!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32684,31985,14:2",
+        "coords": [
+            32684,
+            31985,
+            14
         ]
     },
     {
@@ -13423,7 +18477,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Traveling_Trader_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32210,31157,7:2",
+        "coords": [
+            32210,
+            31157,
+            7
+        ]
     },
     {
         "name": "Rata'Mari",
@@ -13440,7 +18500,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Marid_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33036,32624,7:2",
+        "coords": [
+            33036,
+            32624,
+            7
+        ]
     },
     {
         "name": "Ray",
@@ -13455,6 +18521,12 @@
         "dialogues": [
             "If you need help with letters or parcels, just ask me. I can explain everything.",
             "Stay in touch with your friends. Send a letter, let them know you care and such!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32621,32746,6:2",
+        "coords": [
+            32621,
+            32746,
+            6
         ]
     },
     {
@@ -13476,7 +18548,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Killing_in_the_Name_of..._Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32351,32587,7:2",
+        "coords": [
+            32351,
+            32587,
+            7
+        ]
     },
     {
         "name": "Razan",
@@ -13488,7 +18566,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.216-126.148-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33240,32403,7:2",
+        "coords": [
+            33240,
+            32403,
+            7
+        ]
     },
     {
         "name": "Rebel",
@@ -13500,7 +18584,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.185-121.74-9-2-1-1",
         "version": "8.60",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33209,31049,9:2",
+        "coords": [
+            33209,
+            31049,
+            9
+        ]
     },
     {
         "name": "Red Lilly",
@@ -13514,6 +18604,12 @@
         "quests": [],
         "dialogues": [
             "Come visit my little pawnshop! General equipment and such. Don't miss it!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32282,32820,7:2",
+        "coords": [
+            32282,
+            32820,
+            7
         ]
     },
     {
@@ -13530,6 +18626,12 @@
             "Everything was better back when everything was worse.",
             "Ah, the golden days of true battle! Where blood was shed by the righteous and hymns were sung by the victors...",
             "Long time no see!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32255,32152,11:2",
+        "coords": [
+            32255,
+            32152,
+            11
         ]
     },
     {
@@ -13542,7 +18644,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.54-122.19-6-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32822,31250,6:2",
+        "coords": [
+            32822,
+            31250,
+            6
+        ]
     },
     {
         "name": "Reed",
@@ -13559,7 +18667,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32802,31102,7:2",
+        "coords": [
+            32802,
+            31102,
+            7
+        ]
     },
     {
         "name": "Rehon",
@@ -13580,6 +18694,12 @@
             "Will I ever get out of here?",
             "It's about time someone showed up! Maybe you are more chatty than my skinny friend here!",
             "Hey skeleton, my friend, what do you think?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32760,31375,15:2",
+        "coords": [
+            32760,
+            31375,
+            15
         ]
     },
     {
@@ -13596,6 +18716,12 @@
             "Buy some refreshing drinks here! Fruit juice! Coconut milk!",
             "Cookies! Cookies!",
             "Fresh fruit! Bananas! Mangoes! Pineapples!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32809,32431,7:2",
+        "coords": [
+            32809,
+            32431,
+            7
         ]
     },
     {
@@ -13608,7 +18734,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.243-123.137-11-2-1-1",
         "version": "10.10",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32755,31624,11:2",
+        "coords": [
+            32755,
+            31624,
+            11
+        ]
     },
     {
         "name": "Rhargu",
@@ -13620,7 +18752,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.147-127.24-12-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33171,32535,12:2",
+        "coords": [
+            33171,
+            32535,
+            12
+        ]
     },
     {
         "name": "Richard",
@@ -13635,6 +18773,12 @@
         "dialogues": [
             "Fresh meat! Durable provisions! Ropes and shovels!",
             "A rope is the adventurer's best friend!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32057,31880,5:2",
+        "coords": [
+            32057,
+            31880,
+            5
         ]
     },
     {
@@ -13652,7 +18796,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Paradox_Tower_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32479,31901,2:2",
+        "coords": [
+            32479,
+            31901,
+            2
+        ]
     },
     {
         "name": "Robert",
@@ -13666,6 +18816,12 @@
         "quests": [],
         "dialogues": [
             "Selling weapons - as sharp and sturdy as you can imagine!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32233,31071,6:2",
+        "coords": [
+            32233,
+            31071,
+            6
         ]
     },
     {
@@ -13678,7 +18834,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.31-125.252-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32287,32251,6:2",
+        "coords": [
+            32287,
+            32251,
+            6
+        ]
     },
     {
         "name": "Robson",
@@ -13693,6 +18855,12 @@
         "dialogues": [
             "Just great. Getting stranded on a remote underground isle was not that bad but now I'm becoming a tourist attraction!",
             "*mumbles*"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32526,32020,13:2",
+        "coords": [
+            32526,
+            32020,
+            13
         ]
     },
     {
@@ -13714,6 +18882,12 @@
             "Ack.",
             "Move along.",
             "What do you want from me?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33453,31329,7:2",
+        "coords": [
+            33453,
+            31329,
+            7
         ]
     },
     {
@@ -13731,6 +18905,12 @@
             "I can help you, just come over here.",
             "Only the best for you.",
             "Are you hurt?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33444,31320,9:2",
+        "coords": [
+            33444,
+            31320,
+            9
         ]
     },
     {
@@ -13743,7 +18923,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.178-122.70-6-2-1-1",
         "version": "9.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33458,31301,6:2",
+        "coords": [
+            33458,
+            31301,
+            6
+        ]
     },
     {
         "name": "Roderick",
@@ -13755,7 +18941,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.160-123.211-6-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32672,31698,6:2",
+        "coords": [
+            32672,
+            31698,
+            6
+        ]
     },
     {
         "name": "Rodney",
@@ -13769,6 +18961,12 @@
         "quests": [],
         "dialogues": [
             "Apples, cherries, grapes and pears! All fresh, all tasty!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32971,32040,6:2",
+        "coords": [
+            32971,
+            32040,
+            6
         ]
     },
     {
@@ -13789,6 +18987,12 @@
             "<grumble> Work, work, work...",
             "<grumble> A slave driver, that's what he is.",
             "<grumble> I wish he'd stop hollerin'. I'm gettin' deaf."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33035,32134,7:2",
+        "coords": [
+            33035,
+            32134,
+            7
         ]
     },
     {
@@ -13803,6 +19007,12 @@
         "quests": [],
         "dialogues": [
             "Don't run into the mines with too much money in your pockets. Better leave it here."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33021,32052,6:2",
+        "coords": [
+            33021,
+            32052,
+            6
         ]
     },
     {
@@ -13817,6 +19027,12 @@
         "quests": [],
         "dialogues": [
             "Check out my good and sturdy weapons!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32913,32116,6:2",
+        "coords": [
+            32913,
+            32116,
+            6
         ]
     },
     {
@@ -13829,7 +19045,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.212-121.81-5-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32212,31056,5:2",
+        "coords": [
+            32212,
+            31056,
+            5
+        ]
     },
     {
         "name": "Rose",
@@ -13843,6 +19065,12 @@
         "quests": [],
         "dialogues": [
             "Have a look at my beautiful flowers!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32971,32033,6:2",
+        "coords": [
+            32971,
+            32033,
+            6
         ]
     },
     {
@@ -13858,6 +19086,12 @@
         "dialogues": [
             "Flowers are one of the most beautiful gifts that Crunor blessed us with.",
             "Celebrate life and nature!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32537,32827,7:2",
+        "coords": [
+            32537,
+            32827,
+            7
         ]
     },
     {
@@ -13870,7 +19104,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.239-127.200-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32239,32711,7:2",
+        "coords": [
+            32239,
+            32711,
+            7
+        ]
     },
     {
         "name": "Roswitha",
@@ -13885,6 +19125,12 @@
         "dialogues": [
             "Come on in! Have a pint of glooth with your mates!",
             "Business is slow nowadays. <sigh>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33584,31941,7:2",
+        "coords": [
+            33584,
+            31941,
+            7
         ]
     },
     {
@@ -13899,6 +19145,12 @@
         "quests": [],
         "dialogues": [
             "<sigh> The world has grown complicated since my youth."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32209,32296,7:2",
+        "coords": [
+            32209,
+            32296,
+            7
         ]
     },
     {
@@ -13921,6 +19173,12 @@
             "Mmmh, do you feel the thrill of the hunt, men?",
             "Alright, seven pairs of antlers, twenty pelts, two... hey, guys where's the rest of the rabbit feet?! I hope you all know that this lucky charm business is just superstitious nonsense...",
             "Be on your guard!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32657,32200,7:2",
+        "coords": [
+            32657,
+            32200,
+            7
         ]
     },
     {
@@ -13937,6 +19195,12 @@
             "Play it rough in the arena!",
             "Taste blood in the one and only sewer arena!",
             "Oi!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33536,31831,9:2",
+        "coords": [
+            33536,
+            31831,
+            9
         ]
     },
     {
@@ -13951,6 +19215,12 @@
         "quests": [],
         "dialogues": [
             "Selling and buying fine weapons!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32324,31793,7:2",
+        "coords": [
+            32324,
+            31793,
+            7
         ]
     },
     {
@@ -13963,7 +19233,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.188-124.68-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33212,31811,6:2",
+        "coords": [
+            33212,
+            31811,
+            6
+        ]
     },
     {
         "name": "Ruprecht",
@@ -13975,7 +19251,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=124.207-123.232-7-2-1-1",
         "version": "7.9",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#31951,31719,7:2",
+        "coords": [
+            31951,
+            31719,
+            7
+        ]
     },
     {
         "name": "Saideh",
@@ -13992,7 +19274,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Kilmaresh_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33844,31637,7:2",
+        "coords": [
+            33844,
+            31637,
+            7
+        ]
     },
     {
         "name": "Salbra",
@@ -14010,6 +19298,12 @@
             "The fine arts of magic - rune and spellcraft!",
             "Heal the world - make a better place!",
             "Runes and spells - a beginner's guide!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32097,32010,7:2",
+        "coords": [
+            32097,
+            32010,
+            7
         ]
     },
     {
@@ -14037,6 +19331,12 @@
         ],
         "dialogues": [
             "Hello there, adventurer! Need a deal in weapons or armor? I'm your man!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32360,32198,7:2",
+        "coords": [
+            32360,
+            32198,
+            7
         ]
     },
     {
@@ -14054,7 +19354,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Assassin_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33028,32416,4:2",
+        "coords": [
+            33028,
+            32416,
+            4
+        ]
     },
     {
         "name": "Sandomo",
@@ -14075,7 +19381,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Adventures_of_Galthen_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33505,32551,7:2",
+        "coords": [
+            33505,
+            32551,
+            7
+        ]
     },
     {
         "name": "Sandra",
@@ -14087,7 +19399,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.234-124.96-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33258,31839,7:2",
+        "coords": [
+            33258,
+            31839,
+            7
+        ]
     },
     {
         "name": "Saraki",
@@ -14099,7 +19417,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.185-127.253-4-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33721,32764,4:2",
+        "coords": [
+            33721,
+            32764,
+            4
+        ]
     },
     {
         "name": "Sarina",
@@ -14113,6 +19437,12 @@
         "quests": [],
         "dialogues": [
             "General equipment and all sorts of goods. Visit my store!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32335,31805,7:2",
+        "coords": [
+            32335,
+            31805,
+            7
         ]
     },
     {
@@ -14127,6 +19457,12 @@
         "quests": [],
         "dialogues": [
             "Fresh drinks for all you love birds!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32078,32415,7:2",
+        "coords": [
+            32078,
+            32415,
+            7
         ]
     },
     {
@@ -14141,6 +19477,12 @@
         "quests": [],
         "dialogues": [
             "Hey there, adventurer! Need a little rest in my inn? Have some food!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32138,31658,7:2",
+        "coords": [
+            32138,
+            31658,
+            7
         ]
     },
     {
@@ -14164,6 +19506,12 @@
             "You! Yes, you! Come here! We need a machete to clear those swamp thickets!",
             "Darn it! Why did that stupid boy George lose the reserve grind stones in the swamp. We'll never make good way this way!",
             "You there, Mr-I-lost-my-knife-in-the-swamp! Make yourself useful, will you? Go see Norman and get a job!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33039,32000,7:2",
+        "coords": [
+            33039,
+            32000,
+            7
         ]
     },
     {
@@ -14176,7 +19524,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.165-124.238-7-2-1-1",
         "version": "9.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33189,31981,7:2",
+        "coords": [
+            33189,
+            31981,
+            7
+        ]
     },
     {
         "name": "Scutty",
@@ -14199,6 +19553,12 @@
         ],
         "dialogues": [
             "Stupid tool. Where are you? Why do you interrupt me in doing my job."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32577,31914,12:2",
+        "coords": [
+            32577,
+            31914,
+            12
         ]
     },
     {
@@ -14211,7 +19571,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.91-127.111-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32347,32622,7:2",
+        "coords": [
+            32347,
+            32622,
+            7
+        ]
     },
     {
         "name": "Ser Tybald",
@@ -14223,7 +19589,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.72-124.137-4-2-1-1",
         "version": "10.55",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32072,31880,4:2",
+        "coords": [
+            32072,
+            31880,
+            4
+        ]
     },
     {
         "name": "Serafin",
@@ -14240,7 +19612,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Blood_Brothers_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32852,31208,7:2",
+        "coords": [
+            32852,
+            31208,
+            7
+        ]
     },
     {
         "name": "Servant Sentry",
@@ -14261,6 +19639,12 @@
             "Heed. Your. Will. We. Will.",
             "Intruder. Intrude. Must. Explain.",
             "Ssssttttoooopppp."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33311,31836,7:2",
+        "coords": [
+            33311,
+            31836,
+            7
         ]
     },
     {
@@ -14277,6 +19661,12 @@
             "Come in and order one of my deliciousss mealsss. How about moa steaksss spiced with red pepper and a cherry pudding as dessssert?",
             "Come in and order one of my deliciousss mealsss. How about pan-fried lobssster with roasssted coconut riccce and a glassss of mango juiccce?",
             "Come in and order one of my deliciousss mealsss. How about sssauteed ssstarleaf and ssscrambled turtle eggsss with coconut bread?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33741,32768,5:2",
+        "coords": [
+            33741,
+            32768,
+            5
         ]
     },
     {
@@ -14299,6 +19689,12 @@
             "Get some training in the academy!",
             "Feeling lost? Ask me for help!",
             "Gain some knowledge in the academy!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32104,32189,7:2",
+        "coords": [
+            32104,
+            32189,
+            7
         ]
     },
     {
@@ -14315,6 +19711,12 @@
             "Rainin' blood!",
             "In victory or death!",
             "Show your heart of steel!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33375,31831,9:2",
+        "coords": [
+            33375,
+            31831,
+            9
         ]
     },
     {
@@ -14327,7 +19729,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.196-126.154-7-2-1-1",
         "version": "6.61-6.97",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33220,32409,7:2",
+        "coords": [
+            33220,
+            32409,
+            7
+        ]
     },
     {
         "name": "Shanar",
@@ -14342,6 +19750,12 @@
         "dialogues": [
             "Fine elven armor and weapons. Have a look.",
             "Looking for protective spells for druids? I can teach you."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32659,31656,8:2",
+        "coords": [
+            32659,
+            31656,
+            8
         ]
     },
     {
@@ -14359,6 +19773,12 @@
             "Master the bow to shoot an arrow in the knee!",
             "Be a Jack of all trades, be a paladin!",
             "Noble hunter, versatile adventurer - that's the paladin!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32085,32010,7:2",
+        "coords": [
+            32085,
+            32010,
+            7
         ]
     },
     {
@@ -14373,6 +19793,12 @@
         "quests": [],
         "dialogues": [
             "Need help with the Character World Transfer? Come to me! I answer all of your questions."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32051,32367,6:2",
+        "coords": [
+            32051,
+            32367,
+            6
         ]
     },
     {
@@ -14390,7 +19816,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Green_Djinn_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32384,31777,7:2",
+        "coords": [
+            32384,
+            31777,
+            7
+        ]
     },
     {
         "name": "Sherry McRonald",
@@ -14402,7 +19834,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.134-125.241-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32390,32240,7:2",
+        "coords": [
+            32390,
+            32240,
+            7
+        ]
     },
     {
         "name": "Shiantis",
@@ -14416,6 +19854,12 @@
         "quests": [],
         "dialogues": [
             "Containers, decoration and general goods, all here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32890,32085,6:2",
+        "coords": [
+            32890,
+            32085,
+            6
         ]
     },
     {
@@ -14437,6 +19881,12 @@
             "I must not disappoint Kallimae.",
             "There were plenty of fish in my net.",
             "What a nice catch of fish. Bastesh blessed me today."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33757,31493,7:2",
+        "coords": [
+            33757,
+            31493,
+            7
         ]
     },
     {
@@ -14449,7 +19899,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.158-123.169-6-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32670,31656,6:2",
+        "coords": [
+            32670,
+            31656,
+            6
+        ]
     },
     {
         "name": "Shirith",
@@ -14461,7 +19917,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.134-123.167-9-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32646,31654,9:2",
+        "coords": [
+            32646,
+            31654,
+            9
+        ]
     },
     {
         "name": "Shirtalis of the Summer Court",
@@ -14473,7 +19935,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.179-125.48-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32179,32047,13:2",
+        "coords": [
+            32179,
+            32047,
+            13
+        ]
     },
     {
         "name": "Shoddy Beggar",
@@ -14495,6 +19963,12 @@
             "That astronomer of the academy simply has no idea what he is dealing with...",
             "Some secrets should better be left uncovered.",
             "Ha, ha... *mumbles* Hmm."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33156,31813,7:2",
+        "coords": [
+            33156,
+            31813,
+            7
         ]
     },
     {
@@ -14507,7 +19981,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.115-124.139-3-2-1-1",
         "version": "10.50",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33651,31882,3:2",
+        "coords": [
+            33651,
+            31882,
+            3
+        ]
     },
     {
         "name": "Shortsighted Dwarf",
@@ -14519,7 +19999,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.167-124.209-12-2-1-1",
         "version": "9.80",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32679,31952,12:2",
+        "coords": [
+            32679,
+            31952,
+            12
+        ]
     },
     {
         "name": "Siestaar",
@@ -14531,7 +20017,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.23-126.132-7-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33559,32387,7:2",
+        "coords": [
+            33559,
+            32387,
+            7
+        ]
     },
     {
         "name": "Siflind",
@@ -14551,6 +20043,12 @@
         "dialogues": [
             "Hmm... the northwind brings bad news.",
             "Need potions or magical equipment, my children? Let me know."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32361,31028,6:2",
+        "coords": [
+            32361,
+            31028,
+            6
         ]
     },
     {
@@ -14565,6 +20063,12 @@
         "quests": [],
         "dialogues": [
             "Hiho adventurers, get your runes, potions, wands and rods here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32626,31922,5:2",
+        "coords": [
+            32626,
+            31922,
+            5
         ]
     },
     {
@@ -14580,6 +20084,12 @@
         "dialogues": [
             "Need a new holy spell to hunt evil creatures? Come on in!",
             "Want to improve your aim, young paladin? Come and buy my bows!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33634,31882,5:2",
+        "coords": [
+            33634,
+            31882,
+            5
         ]
     },
     {
@@ -14605,6 +20115,12 @@
             "Alms! Alms for the poor!",
             "Sir, Ma'am, have a gold coin to spare?",
             "I need help! Please help me!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32186,32467,7:2",
+        "coords": [
+            32186,
+            32467,
+            7
         ]
     },
     {
@@ -14622,7 +20138,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Sinatuki_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32426,31084,7:2",
+        "coords": [
+            32426,
+            31084,
+            7
+        ]
     },
     {
         "name": "Sinclair",
@@ -14644,6 +20166,12 @@
             "Mmh, interesting.",
             "Yes indeed, all of the equipment should be checked and calibrated regularly.",
             "No, we have to give this another go."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33268,31834,2:2",
+        "coords": [
+            33268,
+            31834,
+            2
         ]
     },
     {
@@ -14656,7 +20184,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.67-121.141-7-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32323,31116,7:2",
+        "coords": [
+            32323,
+            31116,
+            7
+        ]
     },
     {
         "name": "Sissek",
@@ -14670,6 +20204,12 @@
         "quests": [],
         "dialogues": [
             "Don't forget to deposssit your money here before you head out for adventure."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33794,32754,5:2",
+        "coords": [
+            33794,
+            32754,
+            5
         ]
     },
     {
@@ -14692,6 +20232,12 @@
             "Mother?! Oh no, now I have to do this all over again.",
             "Mhmhmhmhm.",
             "Lalala..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33275,31755,5:2",
+        "coords": [
+            33275,
+            31755,
+            5
         ]
     },
     {
@@ -14709,7 +20255,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Treasure_Hunt_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32131,32969,11:2",
+        "coords": [
+            32131,
+            32969,
+            11
+        ]
     },
     {
         "name": "Skip",
@@ -14732,6 +20284,12 @@
             "FOUR, FIVE, FFIIIIIX!",
             "Talk to meeeee pleaffe! CAAAWWW!",
             "Come here! Come here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32122,32967,11:2",
+        "coords": [
+            32122,
+            32967,
+            11
         ]
     },
     {
@@ -14744,7 +20302,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.194-125.38-8-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32450,32037,8:2",
+        "coords": [
+            32450,
+            32037,
+            8
+        ]
     },
     {
         "name": "Smaralda",
@@ -14758,6 +20322,12 @@
         "quests": [],
         "dialogues": [
             "I can feel the wind of fate!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32235,32294,7:2",
+        "coords": [
+            32235,
+            32294,
+            7
         ]
     },
     {
@@ -14772,6 +20342,12 @@
         "quests": [],
         "dialogues": [
             "Spellssssssssss... druidssssssss...."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32979,32086,6:2",
+        "coords": [
+            32979,
+            32086,
+            6
         ]
     },
     {
@@ -14789,7 +20365,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Thieves_Guild_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32657,32188,8:2",
+        "coords": [
+            32657,
+            32188,
+            8
+        ]
     },
     {
         "name": "Sniff",
@@ -14810,6 +20392,12 @@
             "My pretty goods ... lost.",
             "Hm ... who there?",
             "Yip yip!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33002,32098,7:2",
+        "coords": [
+            33002,
+            32098,
+            7
         ]
     },
     {
@@ -14822,7 +20410,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.53-121.246-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32821,31221,7:2",
+        "coords": [
+            32821,
+            31221,
+            7
+        ]
     },
     {
         "name": "Solkrin",
@@ -14842,6 +20436,12 @@
             "Leopold! I think your jawbone just dropped into your cup!",
             "Isn't that a pip?",
             "Why don't you drop me a line some time?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32935,32253,8:2",
+        "coords": [
+            32935,
+            32253,
+            8
         ]
     },
     {
@@ -14856,6 +20456,12 @@
         "quests": [],
         "dialogues": [
             "It is not my style to yell around here. We can have a private conversation if you are interested in the sorcerer vocation."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32089,32003,7:2",
+        "coords": [
+            32089,
+            32003,
+            7
         ]
     },
     {
@@ -14886,6 +20492,12 @@
             "So my initial calculations had been correct!",
             "Looks like I have to find another way then.",
             "Hm, I need to recapitulate my equipment..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33268,31831,1:2",
+        "coords": [
+            33268,
+            31831,
+            1
         ]
     },
     {
@@ -14902,6 +20514,12 @@
             "Gather around!",
             "I will teach you the ways of the spirits.",
             "<whispers> Ugh... these younglings..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32879,32111,7:2",
+        "coords": [
+            32879,
+            32111,
+            7
         ]
     },
     {
@@ -14918,6 +20536,12 @@
             "Squeak!",
             "Yip yip.",
             "Hm? Who's there?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32287,32810,10:2",
+        "coords": [
+            32287,
+            32810,
+            10
         ]
     },
     {
@@ -14934,6 +20558,12 @@
             "Your soul will be mine!",
             "MUHAHAHAHAHA!",
             "I SMELL FEEEEAR!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32947,32104,6:2",
+        "coords": [
+            32947,
+            32104,
+            6
         ]
     },
     {
@@ -14955,7 +20585,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Vampire_Hunter_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32589,31962,7:2",
+        "coords": [
+            32589,
+            31962,
+            7
+        ]
     },
     {
         "name": "Strange Pipe",
@@ -14972,7 +20608,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Hero_of_Rathleton_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33531,31949,14:2",
+        "coords": [
+            33531,
+            31949,
+            14
+        ]
     },
     {
         "name": "Stressed Storeman",
@@ -14988,6 +20630,12 @@
             "<sigh> Sir, there are still other people waiting. Please pick your reward now.",
             "I already showed you all items.",
             "Take this one or that one! Make your choice!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32819,32425,7:2",
+        "coords": [
+            32819,
+            32425,
+            7
         ]
     },
     {
@@ -15005,7 +20653,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Dream_Courts_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32699,32246,8:2",
+        "coords": [
+            32699,
+            32246,
+            8
+        ]
     },
     {
         "name": "Stutch",
@@ -15017,7 +20671,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.54-125.170-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32310,32169,6:2",
+        "coords": [
+            32310,
+            32169,
+            6
+        ]
     },
     {
         "name": "Sundara",
@@ -15032,6 +20692,12 @@
         "dialogues": [
             "Health potions! Mana potions! Buy them here!",
             "All kinds of potions available here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33823,32772,4:2",
+        "coords": [
+            33823,
+            32772,
+            4
         ]
     },
     {
@@ -15046,6 +20712,12 @@
         "quests": [],
         "dialogues": [
             "Yes indeed, it's a wise idea to store your money in your bank account."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32320,32257,7:2",
+        "coords": [
+            32320,
+            32257,
+            7
         ]
     },
     {
@@ -15066,6 +20738,12 @@
         "dialogues": [
             "Ha ha ha, it always amuses me to see those strangers passing out over our barbarian mead.",
             "There is something in the air that worries me..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32202,31152,7:2",
+        "coords": [
+            32202,
+            31152,
+            7
         ]
     },
     {
@@ -15078,7 +20756,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.45-123.92-7-2-1-1",
         "version": "6.2",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32045,31579,7:2",
+        "coords": [
+            32045,
+            31579,
+            7
+        ]
     },
     {
         "name": "Swolt",
@@ -15090,7 +20774,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.226-123.53-10-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32994,31540,10:2",
+        "coords": [
+            32994,
+            31540,
+            10
+        ]
     },
     {
         "name": "Sylvester",
@@ -15102,7 +20792,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.129-125.145-4-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32897,32144,4:2",
+        "coords": [
+            32897,
+            32144,
+            4
+        ]
     },
     {
         "name": "Taegen",
@@ -15123,6 +20819,12 @@
             "I'd like to take a walk with Aurita.",
             "I miss Aurita's golden hair. *sigh*",
             "Pas in boldly tyll thow com to an hall the feyrist undir sky ... *sings*"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33493,32225,7:2",
+        "coords": [
+            33493,
+            32225,
+            7
         ]
     },
     {
@@ -15135,7 +20837,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.211-125.35-5-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32979,32034,5:2",
+        "coords": [
+            32979,
+            32034,
+            5
+        ]
     },
     {
         "name": "Talila",
@@ -15151,6 +20859,12 @@
             "Are you interested in a trade?",
             "Don't touch the wings, they're delicate.",
             "Tralllalalla."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33506,32221,7:2",
+        "coords": [
+            33506,
+            32221,
+            7
         ]
     },
     {
@@ -15168,7 +20882,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Postman_Missions_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32563,31893,12:2",
+        "coords": [
+            32563,
+            31893,
+            12
+        ]
     },
     {
         "name": "Tamara",
@@ -15180,7 +20900,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.126-121.83-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32894,31058,7:2",
+        "coords": [
+            32894,
+            31058,
+            7
+        ]
     },
     {
         "name": "Tamed Lion",
@@ -15196,6 +20922,12 @@
             "Roarr.",
             "Grrr.",
             "Rwarrr."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33873,31489,4:2",
+        "coords": [
+            33873,
+            31489,
+            4
         ]
     },
     {
@@ -15213,7 +20945,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32659,31211,8:2",
+        "coords": [
+            32659,
+            31211,
+            8
+        ]
     },
     {
         "name": "Tamoril",
@@ -15234,6 +20972,12 @@
             "Come a little closer mortal.",
             "FCHHHHH!",
             "GRRRRRRR!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32911,31018,5:2",
+        "coords": [
+            32911,
+            31018,
+            5
         ]
     },
     {
@@ -15248,6 +20992,12 @@
         "quests": [],
         "dialogues": [
             "Meat, ham, fish and other delicacies freshly imported!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32082,32437,7:2",
+        "coords": [
+            32082,
+            32437,
+            7
         ]
     },
     {
@@ -15262,6 +21012,12 @@
         "quests": [],
         "dialogues": [
             "Potions, wands and runes for aspiring magicians."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32622,32739,5:2",
+        "coords": [
+            32622,
+            32739,
+            5
         ]
     },
     {
@@ -15277,6 +21033,12 @@
         "dialogues": [
             "Feel the wind in your hair during one of my carpet rides!",
             "A ride on a magical carpet. There's no better way to travel!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33958,31513,0:2",
+        "coords": [
+            33958,
+            31513,
+            0
         ]
     },
     {
@@ -15289,7 +21051,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.149-121.223-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32917,31198,7:2",
+        "coords": [
+            32917,
+            31198,
+            7
+        ]
     },
     {
         "name": "Tarisu",
@@ -15301,7 +21069,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.5-128.90-6-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33797,32857,6:2",
+        "coords": [
+            33797,
+            32857,
+            6
+        ]
     },
     {
         "name": "Tarun",
@@ -15322,6 +21096,12 @@
             "My poor brother!",
             "Why did he follow this woman? I told him she's evil!",
             "I fear he is already lost."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32974,32715,7:2",
+        "coords": [
+            32974,
+            32715,
+            7
         ]
     },
     {
@@ -15334,7 +21114,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.236-122.232-3-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33004,31463,3:2",
+        "coords": [
+            33004,
+            31463,
+            3
+        ]
     },
     {
         "name": "Taya",
@@ -15355,6 +21141,12 @@
             "Ah, the pleasures to be an oracle!",
             "Praised be Suon, the Benevolent Sun.",
             "The steppe is dangerous these days."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33815,31463,7:2",
+        "coords": [
+            33815,
+            31463,
+            7
         ]
     },
     {
@@ -15371,6 +21163,12 @@
             "I don't dare to go out there on my own.",
             "My dreams last night have been ambiguous.",
             "The steppes are dangerous these days."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33838,31691,5:2",
+        "coords": [
+            33838,
+            31691,
+            5
         ]
     },
     {
@@ -15391,6 +21189,12 @@
         "dialogues": [
             "They must be rescued!",
             "Oh no, no, NO! Whatever shall I do?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32727,31419,14:2",
+        "coords": [
+            32727,
+            31419,
+            14
         ]
     },
     {
@@ -15412,7 +21216,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33276,31798,6:2",
+        "coords": [
+            33276,
+            31798,
+            6
+        ]
     },
     {
         "name": "Telas Golem",
@@ -15426,6 +21236,12 @@
         "quests": [],
         "dialogues": [
             "What .. happened?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33267,31788,11:2",
+        "coords": [
+            33267,
+            31788,
+            11
         ]
     },
     {
@@ -15449,6 +21265,12 @@
         ],
         "dialogues": [
             "Sigh."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33166,31806,6:2",
+        "coords": [
+            33166,
+            31806,
+            6
         ]
     },
     {
@@ -15466,7 +21288,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Oramond_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33645,31947,7:2",
+        "coords": [
+            33645,
+            31947,
+            7
+        ]
     },
     {
         "name": "Tesha",
@@ -15480,6 +21308,12 @@
         "quests": [],
         "dialogues": [
             "May enlightenment be your path."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33135,32820,6:2",
+        "coords": [
+            33135,
+            32820,
+            6
         ]
     },
     {
@@ -15495,6 +21329,12 @@
         "dialogues": [
             "Gems and precious jewels! Also a nice investment for your money.",
             "Interested in some gems? You can enchant them if you are a druid."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32657,31921,9:2",
+        "coords": [
+            32657,
+            31921,
+            9
         ]
     },
     {
@@ -15512,7 +21352,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Tower_Defence_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32535,31772,1:2",
+        "coords": [
+            32535,
+            31772,
+            1
+        ]
     },
     {
         "name": "The Beggar King",
@@ -15529,7 +21375,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Dark_Trails_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33572,31982,8:2",
+        "coords": [
+            33572,
+            31982,
+            8
+        ]
     },
     {
         "name": "The Blind Prophet",
@@ -15546,7 +21398,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Ape_City_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33022,32603,7:2",
+        "coords": [
+            33022,
+            32603,
+            7
+        ]
     },
     {
         "name": "The Bone Master",
@@ -15563,7 +21421,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Dreamer%27s_Challenge_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32793,32225,14:2",
+        "coords": [
+            32793,
+            32225,
+            14
+        ]
     },
     {
         "name": "The Crone",
@@ -15577,6 +21441,12 @@
         "quests": [],
         "dialogues": [
             "Let me mourn in peace."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33229,32521,14:2",
+        "coords": [
+            33229,
+            32521,
+            14
         ]
     },
     {
@@ -15589,7 +21459,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.218-125.54-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32218,32053,13:2",
+        "coords": [
+            32218,
+            32053,
+            13
+        ]
     },
     {
         "name": "The Destiny Seer",
@@ -15605,6 +21481,12 @@
             "Feeling lost, child? Ask me, and I will guide you.",
             "Let me help you find your destiny.",
             "I can help you find your vocation."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32115,32014,7:2",
+        "coords": [
+            32115,
+            32014,
+            7
         ]
     },
     {
@@ -15624,6 +21506,12 @@
         ],
         "dialogues": [
             "Praised be the gods, and praised be the Nightmare Knights."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32844,32227,14:2",
+        "coords": [
+            32844,
+            32227,
+            14
         ]
     },
     {
@@ -15645,6 +21533,12 @@
             "Rulership is a duty as well as a burden.",
             "I am worrying about the Fafnar cultists. I am sure they are up to something.",
             "It has been a long time since I have spoken to Arishum. I should invite him or pay him a visit. I miss our conversations."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33870,31496,3:2",
+        "coords": [
+            33870,
+            31496,
+            3
         ]
     },
     {
@@ -15662,7 +21556,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/First_Dragon_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33617,31018,13:2",
+        "coords": [
+            33617,
+            31018,
+            13
+        ]
     },
     {
         "name": "The Gate Keeper",
@@ -15678,6 +21578,12 @@
             "Zgk'ch Cthlhg drch, sire.",
             "Ah. I grieve. All those shadows, in despair...",
             "<Chants a dark tune that makes your ears bleed>"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32855,32425,10:2",
+        "coords": [
+            32855,
+            32425,
+            10
         ]
     },
     {
@@ -15694,6 +21600,12 @@
             "I really have to find this scroll. Where did I put it?",
             "Too much dust here. I should tidy up on occasion.",
             "Someone opened the Grimoire of Flames without permission. Egregious!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33873,31488,5:2",
+        "coords": [
+            33873,
+            31488,
+            5
         ]
     },
     {
@@ -15706,7 +21618,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.104-125.190-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32104,32189,6:2",
+        "coords": [
+            32104,
+            32189,
+            6
+        ]
     },
     {
         "name": "The Orc King",
@@ -15735,6 +21653,12 @@
             "Harrrrk! You think you are strong now? You shall never escape my wrath! I am immortal!",
             "Blubb.",
             "Yes, flee this place, but you will never escape my revenge!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32983,31727,9:2",
+        "coords": [
+            32983,
+            31727,
+            9
         ]
     },
     {
@@ -15766,6 +21690,12 @@
         ],
         "dialogues": [
             "Uhhhhhh...."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32260,31862,14:2",
+        "coords": [
+            32260,
+            31862,
+            14
         ]
     },
     {
@@ -15783,7 +21713,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Feaster_of_Souls_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33232,31695,7:2",
+        "coords": [
+            33232,
+            31695,
+            7
+        ]
     },
     {
         "name": "Theodora",
@@ -15795,7 +21731,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.76-125.183-7-2-1-1",
         "version": "12.87.12038",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32332,32182,7:2",
+        "coords": [
+            32332,
+            32182,
+            7
+        ]
     },
     {
         "name": "Theodore Loveless",
@@ -15812,7 +21754,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32362,32786,6:2",
+        "coords": [
+            32362,
+            32786,
+            6
+        ]
     },
     {
         "name": "Thomas",
@@ -15824,7 +21772,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.232-124.94-4-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33256,31837,4:2",
+        "coords": [
+            33256,
+            31837,
+            4
+        ]
     },
     {
         "name": "Thorgrin",
@@ -15836,7 +21790,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.1-123.65-14-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33025,31552,14:2",
+        "coords": [
+            33025,
+            31552,
+            14
+        ]
     },
     {
         "name": "Thorwulf",
@@ -15848,7 +21808,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.11-121.115-6-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32267,31090,6:2",
+        "coords": [
+            32267,
+            31090,
+            6
+        ]
     },
     {
         "name": "Tibra",
@@ -15865,7 +21831,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32318,31782,7:2",
+        "coords": [
+            32318,
+            31782,
+            7
+        ]
     },
     {
         "name": "Tigo",
@@ -15882,7 +21854,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Cults_of_Tibia_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32692,31542,9:2",
+        "coords": [
+            32692,
+            31542,
+            9
+        ]
     },
     {
         "name": "Tik'hi Tak'he",
@@ -15901,6 +21879,12 @@
         ],
         "dialogues": [
             "May the great raccoon smile upon you!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33729,31342,7:2",
+        "coords": [
+            33729,
+            31342,
+            7
         ]
     },
     {
@@ -15918,7 +21902,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Inquisition_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32428,32225,6:2",
+        "coords": [
+            32428,
+            32225,
+            6
+        ]
     },
     {
         "name": "Timothy",
@@ -15935,7 +21925,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32789,31224,7:2",
+        "coords": [
+            32789,
+            31224,
+            7
+        ]
     },
     {
         "name": "Timur",
@@ -15950,6 +21946,12 @@
         "dialogues": [
             "Equipment and general goods!",
             "Selling ammunition and buying bows and crossbows!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32191,32442,7:2",
+        "coords": [
+            32191,
+            32442,
+            7
         ]
     },
     {
@@ -15971,6 +21973,12 @@
             "*yawn*",
             "I just want to sleep.",
             "Sooo tired."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32307,31644,7:2",
+        "coords": [
+            32307,
+            31644,
+            7
         ]
     },
     {
@@ -15983,7 +21991,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.107-125.210-6-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32363,32209,6:2",
+        "coords": [
+            32363,
+            32209,
+            6
+        ]
     },
     {
         "name": "Tokel",
@@ -15997,6 +22011,12 @@
         "quests": [],
         "dialogues": [
             "Are you hungry? I offer bread, cheese, ham and meat. Perfect for a little snack."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32256,32055,7:2",
+        "coords": [
+            32256,
+            32055,
+            7
         ]
     },
     {
@@ -16018,6 +22038,12 @@
             "Buying fresh corpses of rats, rabbits and wolves.",
             "Oh yeah, I'm also interested in wolf paws and bear paws.",
             "Also buying minotaur leather."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32085,32198,7:2",
+        "coords": [
+            32085,
+            32198,
+            7
         ]
     },
     {
@@ -16040,6 +22066,12 @@
             "This is really sanguine!",
             "Hmm... the conductors are too dry to transmit energy.",
             "Ah, fresh blood. My favourite."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32976,32414,11:2",
+        "coords": [
+            32976,
+            32414,
+            11
         ]
     },
     {
@@ -16057,7 +22089,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32695,31256,7:2",
+        "coords": [
+            32695,
+            31256,
+            7
+        ]
     },
     {
         "name": "Tooth Fairy",
@@ -16078,6 +22116,12 @@
             "I have to ... No, I don't dare ...",
             "This is a very strange part of the world.",
             "The children are waiting for their presents."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32701,31731,7:2",
+        "coords": [
+            32701,
+            31731,
+            7
         ]
     },
     {
@@ -16095,7 +22139,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Kissing_a_Pig_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32320,31805,8:2",
+        "coords": [
+            32320,
+            31805,
+            8
+        ]
     },
     {
         "name": "Topsy",
@@ -16109,6 +22159,12 @@
         "quests": [],
         "dialogues": [
             "Runes, wands, rods, health and mana potions! Have a look!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32415,32169,7:2",
+        "coords": [
+            32415,
+            32169,
+            7
         ]
     },
     {
@@ -16121,7 +22177,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.185-128.56-7-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32185,32823,7:2",
+        "coords": [
+            32185,
+            32823,
+            7
+        ]
     },
     {
         "name": "Tothdral",
@@ -16133,7 +22195,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.124-128.99-6-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33148,32866,6:2",
+        "coords": [
+            33148,
+            32866,
+            6
+        ]
     },
     {
         "name": "Towncryer",
@@ -16149,6 +22217,12 @@
             "Hear me! Hear me! The mage Wyrdin in the Edron academy is looking for brave adventurers to undertake a task!",
             "Hear me! Hear me! The postmaster's guild has open spots for aspiring postmen! Contact Kevin Postner at the post office in the plains south of Kazordoon!",
             "Hear me! Hear me! The inquisition is looking for daring people to fight evil! Apply at the inquisition headquarters next to the Thaian jail!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32322,32226,7:2",
+        "coords": [
+            32322,
+            32226,
+            7
         ]
     },
     {
@@ -16161,7 +22235,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.51-125.185-5-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32307,32184,5:2",
+        "coords": [
+            32307,
+            32184,
+            5
+        ]
     },
     {
         "name": "Trisha",
@@ -16178,7 +22258,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Warrior_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32348,31747,7:2",
+        "coords": [
+            32348,
+            31747,
+            7
+        ]
     },
     {
         "name": "Tristan",
@@ -16190,7 +22276,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.139-128.58-2-2-1-1",
         "version": "7.8",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32395,32825,2:2",
+        "coords": [
+            32395,
+            32825,
+            2
+        ]
     },
     {
         "name": "Tulf",
@@ -16202,7 +22294,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.74-124.184-3-2-1-1",
         "version": "6.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32586,31927,3:2",
+        "coords": [
+            32586,
+            31927,
+            3
+        ]
     },
     {
         "name": "Turvy",
@@ -16216,6 +22314,12 @@
         "quests": [],
         "dialogues": [
             "Courageous adventurers, come buy your weapons and armors here!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32414,32176,7:2",
+        "coords": [
+            32414,
+            32176,
+            7
         ]
     },
     {
@@ -16235,6 +22339,12 @@
             "Weak punch? Deal out some heavy damage with magic!",
             "Staffs, wands, rods - the true weapons of power!",
             "Shoot your enemy with energy spheres!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32072,32010,7:2",
+        "coords": [
+            32072,
+            32010,
+            7
         ]
     },
     {
@@ -16252,7 +22362,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32317,32822,7:2",
+        "coords": [
+            32317,
+            32822,
+            7
+        ]
     },
     {
         "name": "Ubaid",
@@ -16269,7 +22385,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Efreet_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33046,32621,6:2",
+        "coords": [
+            33046,
+            32621,
+            6
+        ]
     },
     {
         "name": "Udu",
@@ -16281,7 +22403,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=132.57-128.20-2-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33849,32787,2:2",
+        "coords": [
+            33849,
+            32787,
+            2
+        ]
     },
     {
         "name": "Ukea",
@@ -16293,7 +22421,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.139-123.177-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32651,31664,6:2",
+        "coords": [
+            32651,
+            31664,
+            6
+        ]
     },
     {
         "name": "Ula",
@@ -16309,6 +22443,12 @@
             "Sorcs rule!",
             "Fry your foes!",
             "Wizards wield a mean staff!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32067,32012,7:2",
+        "coords": [
+            32067,
+            32012,
+            7
         ]
     },
     {
@@ -16321,7 +22461,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.227-122.237-1-2-1-1",
         "version": "8.54",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32995,31468,1:2",
+        "coords": [
+            32995,
+            31468,
+            1
+        ]
     },
     {
         "name": "Ulrik",
@@ -16335,6 +22481,12 @@
         "quests": [],
         "dialogues": [
             "Weapons and armors for young knights. Come have a look."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32282,32055,7:2",
+        "coords": [
+            32282,
+            32055,
+            7
         ]
     },
     {
@@ -16352,7 +22504,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Djinn_War_-_Marid_Faction"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33102,32530,6:2",
+        "coords": [
+            33102,
+            32530,
+            6
+        ]
     },
     {
         "name": "Uncle",
@@ -16369,7 +22527,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Secret_Service_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32951,32039,4:2",
+        "coords": [
+            32951,
+            32039,
+            4
+        ]
     },
     {
         "name": "Undal",
@@ -16386,7 +22550,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Dream_Courts_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33710,32115,4:2",
+        "coords": [
+            33710,
+            32115,
+            4
+        ]
     },
     {
         "name": "Urkalio",
@@ -16400,6 +22570,12 @@
         "quests": [],
         "dialogues": [
             "Enjoy a good drink in the Hard Rock Tavern!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32913,32080,10:2",
+        "coords": [
+            32913,
+            32080,
+            10
         ]
     },
     {
@@ -16412,7 +22588,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.239-128.88-14-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33519,32855,14:2",
+        "coords": [
+            33519,
+            32855,
+            14
+        ]
     },
     {
         "name": "Ursula",
@@ -16424,7 +22606,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.244-124.105-7-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33268,31848,7:2",
+        "coords": [
+            33268,
+            31848,
+            7
+        ]
     },
     {
         "name": "Uso",
@@ -16436,7 +22624,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.68-127.244-8-2-1-1",
         "version": "7.5",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32580,32755,8:2",
+        "coords": [
+            32580,
+            32755,
+            8
+        ]
     },
     {
         "name": "Ustan",
@@ -16453,7 +22647,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Druid_Outfits_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32580,32756,6:2",
+        "coords": [
+            32580,
+            32756,
+            6
+        ]
     },
     {
         "name": "Uzgod",
@@ -16480,6 +22680,12 @@
         ],
         "dialogues": [
             "By the sons of fire! Best weapons in town!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32664,31893,9:2",
+        "coords": [
+            32664,
+            31893,
+            9
         ]
     },
     {
@@ -16499,6 +22705,12 @@
         ],
         "dialogues": [
             "Feel the wind in your hair during one of my carpet rides!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32537,31835,4:2",
+        "coords": [
+            32537,
+            31835,
+            4
         ]
     },
     {
@@ -16514,6 +22726,12 @@
         "dialogues": [
             "Flowers, cakes, presents and valentine cards - only today.",
             "Show how much you care before it's too late."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32272,32048,7:2",
+        "coords": [
+            32272,
+            32048,
+            7
         ]
     },
     {
@@ -16530,6 +22748,12 @@
             "I'm eager for a bath in the lake.",
             "I'm interested in shiny precious things, if you have some.",
             "No, you can't have this cloak."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33507,32222,7:2",
+        "coords": [
+            33507,
+            32222,
+            7
         ]
     },
     {
@@ -16547,7 +22771,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Dream_Courts_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33686,32179,8:2",
+        "coords": [
+            33686,
+            32179,
+            8
+        ]
     },
     {
         "name": "Vascalir",
@@ -16567,6 +22797,12 @@
         "dialogues": [
             "Talk to me if you want to help protecting the village.",
             "Rookgaard needs your help more than ever."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32104,32194,7:2",
+        "coords": [
+            32104,
+            32194,
+            7
         ]
     },
     {
@@ -16579,7 +22815,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.247-127.59-8-2-1-1",
         "version": "13.10.12852",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33783,32570,8:2",
+        "coords": [
+            33783,
+            32570,
+            8
+        ]
     },
     {
         "name": "Velvet",
@@ -16593,6 +22835,12 @@
         "quests": [],
         "dialogues": [
             "Silky smooth pillows and tapestries! No home is perfect without them!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32943,32103,6:2",
+        "coords": [
+            32943,
+            32103,
+            6
         ]
     },
     {
@@ -16607,6 +22855,12 @@
         "quests": [],
         "dialogues": [
             "Have you moved to a new home? I'm the specialist for equipping it."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32138,31671,7:2",
+        "coords": [
+            32138,
+            31671,
+            7
         ]
     },
     {
@@ -16628,6 +22882,12 @@
             "<hicks>",
             "Uhhh... my head... <hicks>",
             "Something ought t-to <hicks> do something a-about this <hicks> troll infestion. Err, <hicks> s-someone."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32564,32650,7:2",
+        "coords": [
+            32564,
+            32650,
+            7
         ]
     },
     {
@@ -16644,6 +22904,12 @@
             "Let the blood flow - preferably not your own!",
             "Test your mettle!",
             "Battle it out in the arena!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32256,32215,8:2",
+        "coords": [
+            32256,
+            32215,
+            8
         ]
     },
     {
@@ -16661,6 +22927,12 @@
             "Wanna dig for some treasures? Grab your shovel or buy one here!",
             "Come here, buy some tasty food and drinks!",
             "Enjoy the festivities here on Vigintia Island!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33494,31038,7:2",
+        "coords": [
+            33494,
+            31038,
+            7
         ]
     },
     {
@@ -16673,7 +22945,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.21-122.6-3-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32789,31237,3:2",
+        "coords": [
+            32789,
+            31237,
+            3
+        ]
     },
     {
         "name": "Virgil",
@@ -16687,6 +22965,12 @@
         "quests": [],
         "dialogues": [
             "Glooth papers rising! Capital!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33627,31893,5:2",
+        "coords": [
+            33627,
+            31893,
+            5
         ]
     },
     {
@@ -16699,7 +22983,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.208-125.79-5-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32976,32078,5:2",
+        "coords": [
+            32976,
+            32078,
+            5
+        ]
     },
     {
         "name": "Vrisaki",
@@ -16711,7 +23001,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.243-127.222-2-2-1-1",
         "version": "12.90.12182",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33779,32733,2:2",
+        "coords": [
+            33779,
+            32733,
+            2
+        ]
     },
     {
         "name": "Vulturenose",
@@ -16733,6 +23029,12 @@
             "Whatever.",
             "<spits>",
             "Huh?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#31977,32855,3:2",
+        "coords": [
+            31977,
+            32855,
+            3
         ]
     },
     {
@@ -16754,6 +23056,12 @@
             "*Grunt*",
             "More meat! More cookies!",
             "Hrmpf, Vuzrog hungry!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33639,31659,7:2",
+        "coords": [
+            33639,
+            31659,
+            7
         ]
     },
     {
@@ -16771,7 +23079,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33944,32116,15:2",
+        "coords": [
+            33944,
+            32116,
+            15
+        ]
     },
     {
         "name": "Wally",
@@ -16783,7 +23097,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.54-125.19-7-2-1-1",
         "version": "7.3",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32566,32018,7:2",
+        "coords": [
+            32566,
+            32018,
+            7
+        ]
     },
     {
         "name": "Walter Jaeger",
@@ -16795,7 +23115,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.124-125.207-7-2-1-1",
         "version": "12.30.9287",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32380,32206,7:2",
+        "coords": [
+            32380,
+            32206,
+            7
+        ]
     },
     {
         "name": "Walter, The Guard",
@@ -16807,7 +23133,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.82-126.22-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32338,32277,7:2",
+        "coords": [
+            32338,
+            32277,
+            7
+        ]
     },
     {
         "name": "Warbert",
@@ -16819,7 +23151,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.167-125.141-6-2-1-1",
         "version": "7.1",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32935,32140,6:2",
+        "coords": [
+            32935,
+            32140,
+            6
+        ]
     },
     {
         "name": "Weakened Forest Fury",
@@ -16840,6 +23178,12 @@
             "Life is fading from the glade.",
             "The trees whisper with fear.",
             "We have to bring life back into the glade!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32613,32263,7:2",
+        "coords": [
+            32613,
+            32263,
+            7
         ]
     },
     {
@@ -16852,7 +23196,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.85-124.233-8-2-1-1",
         "version": "9.62",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32085,31976,8:2",
+        "coords": [
+            32085,
+            31976,
+            8
+        ]
     },
     {
         "name": "Wentworth",
@@ -16869,6 +23219,12 @@
             "Waste not, want not!",
             "Don't burden yourself with too much cash - store it here!",
             "Don't take the money and run - deposit it and walk instead!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32064,31880,6:2",
+        "coords": [
+            32064,
+            31880,
+            6
         ]
     },
     {
@@ -16881,7 +23237,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.166-126.225-5-2-1-1",
         "version": "12.40.9997",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32422,32480,5:2",
+        "coords": [
+            32422,
+            32480,
+            5
+        ]
     },
     {
         "name": "Wesley",
@@ -16898,7 +23260,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Glooth_Factory_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33624,31896,12:2",
+        "coords": [
+            33624,
+            31896,
+            12
+        ]
     },
     {
         "name": "Willard",
@@ -16910,7 +23278,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=129.190-124.49-6-2-1-1",
         "version": "6.4",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33214,31792,6:2",
+        "coords": [
+            33214,
+            31792,
+            6
+        ]
     },
     {
         "name": "Willem",
@@ -16925,6 +23299,12 @@
         "dialogues": [
             "Paladins do it with their eyes closed!",
             "Be the hunter! Be a paladin!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32063,32019,7:2",
+        "coords": [
+            32063,
+            32019,
+            7
         ]
     },
     {
@@ -16937,7 +23317,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.58-124.58-8-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32314,31801,8:2",
+        "coords": [
+            32314,
+            31801,
+            8
+        ]
     },
     {
         "name": "Willie",
@@ -16959,6 +23345,12 @@
             "Buying and selling food!",
             "Make sure you know what you want before you bug me.",
             "You, over there! Stop sniffing around my farm! Either trade with me or leave!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32067,32203,7:2",
+        "coords": [
+            32067,
+            32203,
+            7
         ]
     },
     {
@@ -16974,6 +23366,12 @@
         "dialogues": [
             "Make runes, not death!",
             "Druids rock!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32079,32018,7:2",
+        "coords": [
+            32079,
+            32018,
+            7
         ]
     },
     {
@@ -16994,6 +23392,12 @@
         "dialogues": [
             "Stinky Old Nasty.",
             "Mine precious!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#31990,31882,8:2",
+        "coords": [
+            31990,
+            31882,
+            8
         ]
     },
     {
@@ -17006,7 +23410,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.69-126.20-7-2-1-1",
         "version": "Pre-6.0",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32325,32275,7:2",
+        "coords": [
+            32325,
+            32275,
+            7
+        ]
     },
     {
         "name": "Wyda",
@@ -17031,7 +23441,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32726,31979,6:2",
+        "coords": [
+            32726,
+            31979,
+            6
+        ]
     },
     {
         "name": "Wyrdin",
@@ -17061,6 +23477,12 @@
             "<mumbles> Typical - you can never find a hero when you need one!",
             "<mumbles> Could the bonelord language be the invention of some madman?",
             "<mumbles> The curse algorithm of triplex shadowing has to be two times higher than an overcharged nanoquorx on the peripheral .."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33268,31837,6:2",
+        "coords": [
+            33268,
+            31837,
+            6
         ]
     },
     {
@@ -17073,7 +23495,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=131.240-121.99-7-2-1-1",
         "version": "12.20.9066",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33776,31074,7:2",
+        "coords": [
+            33776,
+            31074,
+            7
+        ]
     },
     {
         "name": "Xed",
@@ -17087,6 +23515,12 @@
         "quests": [],
         "dialogues": [
             "Selling bows, crossbows and ammunition!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32904,32116,6:2",
+        "coords": [
+            32904,
+            32116,
+            6
         ]
     },
     {
@@ -17106,6 +23540,12 @@
         ],
         "dialogues": [
             "Talk to me if you're interested in adventure and excitement."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32622,31860,11:2",
+        "coords": [
+            32622,
+            31860,
+            11
         ]
     },
     {
@@ -17123,7 +23563,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Scatterbrained_Sorcerer_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32399,32221,7:2",
+        "coords": [
+            32399,
+            32221,
+            7
+        ]
     },
     {
         "name": "Xorlosh",
@@ -17140,7 +23586,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Hidden_City_of_Beregar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32613,31498,14:2",
+        "coords": [
+            32613,
+            31498,
+            14
+        ]
     },
     {
         "name": "Yalahari",
@@ -17157,7 +23609,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/In_Service_of_Yalahar_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32801,31188,7:2",
+        "coords": [
+            32801,
+            31188,
+            7
+        ]
     },
     {
         "name": "Yaman",
@@ -17174,7 +23632,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/What_a_Foolish_Quest/Spoiler#Mission_10_-_A_Sweet_Surprise"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33045,32619,2:2",
+        "coords": [
+            33045,
+            32619,
+            2
+        ]
     },
     {
         "name": "Yana",
@@ -17188,6 +23652,12 @@
         "quests": [],
         "dialogues": [
             "Trading tokens! First-class equipment available!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32198,32303,6:2",
+        "coords": [
+            32198,
+            32303,
+            6
         ]
     },
     {
@@ -17202,6 +23672,12 @@
         "quests": [],
         "dialogues": [
             "Armors, helmets, shields and legs. All sizes!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32909,32110,6:2",
+        "coords": [
+            32909,
+            32110,
+            6
         ]
     },
     {
@@ -17214,7 +23690,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.142-124.71-6-2-1-1",
         "version": "9.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32398,31814,6:2",
+        "coords": [
+            32398,
+            31814,
+            6
+        ]
     },
     {
         "name": "Yawno",
@@ -17235,6 +23717,12 @@
             "One of them... I just saw... *yawn* one of them...",
             "Mmhnmnmnmmmh... no, nooo...! Lemme sleep... I don't wanna go to school...",
             "It... *yawn* will show up... sooner or later... *yaaawn*"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32614,32650,7:2",
+        "coords": [
+            32614,
+            32650,
+            7
         ]
     },
     {
@@ -17252,7 +23740,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Blessed_Stake_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32961,32075,7:2",
+        "coords": [
+            32961,
+            32075,
+            7
+        ]
     },
     {
         "name": "Yeo",
@@ -17273,7 +23767,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Glooth_Factory_Quest/Spoiler#The_Gloud_Ship"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33660,31989,7:2",
+        "coords": [
+            33660,
+            31989,
+            7
+        ]
     },
     {
         "name": "Yielothax",
@@ -17290,7 +23790,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Opticording_Sphere_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33928,32136,15:2",
+        "coords": [
+            33928,
+            32136,
+            15
+        ]
     },
     {
         "name": "Yoem",
@@ -17304,6 +23810,12 @@
         "quests": [],
         "dialogues": [
             "Beds, chairs, tables, statues and everything you could imagine for decorating your home!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33305,31965,7:2",
+        "coords": [
+            33305,
+            31965,
+            7
         ]
     },
     {
@@ -17325,6 +23837,12 @@
             "If you are interested in gems and beautiful jewellery, I'm your man!",
             "Fine jewels, rings and amulets!",
             "Gems and jewellery! Best prices in town!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33922,31512,7:2",
+        "coords": [
+            33922,
+            31512,
+            7
         ]
     },
     {
@@ -17337,7 +23855,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=125.213-125.74-13-2-1-1",
         "version": "12.00.7695",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32213,32073,13:2",
+        "coords": [
+            32213,
+            32073,
+            13
+        ]
     },
     {
         "name": "Ysbasra",
@@ -17354,7 +23878,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Cradle_of_Monsters_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33394,31916,8:2",
+        "coords": [
+            33394,
+            31916,
+            8
+        ]
     },
     {
         "name": "Yselda",
@@ -17371,7 +23901,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Adventures_of_Galthen_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32619,32487,12:2",
+        "coords": [
+            32619,
+            32487,
+            12
+        ]
     },
     {
         "name": "Yulas",
@@ -17385,6 +23921,12 @@
         "quests": [],
         "dialogues": [
             "Every home needs at least one table. Come get yours here."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33000,32064,6:2",
+        "coords": [
+            33000,
+            32064,
+            6
         ]
     },
     {
@@ -17399,6 +23941,12 @@
         "quests": [],
         "dialogues": [
             "Handmade furniture only available in the jungle. Don't miss it!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32622,32745,5:2",
+        "coords": [
+            32622,
+            32745,
+            5
         ]
     },
     {
@@ -17424,6 +23972,12 @@
             "I mourn my lozzt brozzerzz and zzizzterzz. May zzeir zzoulzz find peazze.",
             "Great mozzer, how long until you zztrike and show zzem?",
             "Uzzelezz. Uzzelezz!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33356,31410,8:2",
+        "coords": [
+            33356,
+            31410,
+            8
         ]
     },
     {
@@ -17436,7 +23990,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.209-122.55-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32721,31286,7:2",
+        "coords": [
+            32721,
+            31286,
+            7
+        ]
     },
     {
         "name": "Zarifan",
@@ -17458,6 +24018,12 @@
             "<sigh> ohhhh.... memories...",
             "The secrets... too many... sleep...",
             "Loneliness..."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33040,32483,11:2",
+        "coords": [
+            33040,
+            32483,
+            11
         ]
     },
     {
@@ -17477,6 +24043,12 @@
         ],
         "dialogues": [
             "Hey mate, up for a game of dice?"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32931,32070,9:2",
+        "coords": [
+            32931,
+            32070,
+            9
         ]
     },
     {
@@ -17489,7 +24061,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=130.233-126.107-6-2-1-1",
         "version": "10.30",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33513,32362,6:2",
+        "coords": [
+            33513,
+            32362,
+            6
+        ]
     },
     {
         "name": "Zerbrus",
@@ -17507,6 +24085,12 @@
             "No monster shall go past me.",
             "The premium side of Rookgaard lies beyond.",
             "Want to know what monsters are good for you at your level? Just ask me!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32022,32202,6:2",
+        "coords": [
+            32022,
+            32202,
+            6
         ]
     },
     {
@@ -17528,7 +24112,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_Gloud_Ship"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33609,31973,4:2",
+        "coords": [
+            33609,
+            31973,
+            4
+        ]
     },
     {
         "name": "Zethra",
@@ -17542,6 +24132,12 @@
         "quests": [],
         "dialogues": [
             "Come over here if you have to resupply!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#32192,32298,7:2",
+        "coords": [
+            32192,
+            32298,
+            7
         ]
     },
     {
@@ -17554,7 +24150,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=127.171-122.160-12-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32683,31391,12:2",
+        "coords": [
+            32683,
+            31391,
+            12
+        ]
     },
     {
         "name": "Ziyad",
@@ -17569,6 +24171,12 @@
         "dialogues": [
             "I'll show you the world during one of my carpet rides!",
             "No better way to travel than on a magical carpet!"
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33804,32768,2:2",
+        "coords": [
+            33804,
+            32768,
+            2
         ]
     },
     {
@@ -17586,7 +24194,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33103,31119,12:2",
+        "coords": [
+            33103,
+            31119,
+            12
+        ]
     },
     {
         "name": "Zlak",
@@ -17603,7 +24217,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Wrath_of_the_Emperor_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33082,31219,7:2",
+        "coords": [
+            33082,
+            31219,
+            7
+        ]
     },
     {
         "name": "Znozel",
@@ -17615,7 +24235,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=128.54-122.16-7-2-1-1",
         "version": "8.40",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32822,31247,7:2",
+        "coords": [
+            32822,
+            31247,
+            7
+        ]
     },
     {
         "name": "Zoltan",
@@ -17636,7 +24262,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/Summoner_Outfits"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33268,31848,4:2",
+        "coords": [
+            33268,
+            31848,
+            4
+        ]
     },
     {
         "name": "Zora",
@@ -17648,7 +24280,13 @@
         "map": "https://tibia.fandom.com/wiki/Mapper?coords=126.106-122.92-6-2-1-1",
         "version": "8.00",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#32362,31323,6:2",
+        "coords": [
+            32362,
+            31323,
+            6
+        ]
     },
     {
         "name": "Ztiss",
@@ -17665,7 +24303,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33169,31229,11:2",
+        "coords": [
+            33169,
+            31229,
+            11
+        ]
     },
     {
         "name": "Zumtah",
@@ -17686,6 +24330,12 @@
             "I have to check the candles again soon...",
             "Hmmm. Over here, human.",
             "Muhahahaha. Ha."
+        ],
+        "tibiamap": "https://tibiamaps.io/map#33362,31206,8:2",
+        "coords": [
+            33362,
+            31206,
+            8
         ]
     },
     {
@@ -17703,7 +24353,13 @@
                 "quest-url": "https://tibia.fandom.com/wiki/The_New_Frontier_Quest"
             }
         ],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "https://tibiamaps.io/map#33158,31224,7:2",
+        "coords": [
+            33158,
+            31224,
+            7
+        ]
     },
     {
         "name": "Hoaxette",
@@ -17715,7 +24371,9 @@
         "map": "",
         "version": "",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "",
+        "coords": []
     },
     {
         "name": "Bolfona And Drog",
@@ -17727,7 +24385,9 @@
         "map": "",
         "version": "",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "",
+        "coords": []
     },
     {
         "name": "Santa Claus",
@@ -17739,7 +24399,9 @@
         "map": "",
         "version": "",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "",
+        "coords": []
     },
     {
         "name": "Morax Dream",
@@ -17751,6 +24413,8 @@
         "map": "",
         "version": "",
         "quests": [],
-        "dialogues": []
+        "dialogues": [],
+        "tibiamap": "",
+        "coords": []
     }
 ]

--- a/src/mapper_to_tibiamaps.py
+++ b/src/mapper_to_tibiamaps.py
@@ -1,0 +1,75 @@
+import json
+import requests
+import os
+
+
+# The URL or file path of the JSON file containing NPC data
+NPC_JSON = "https://raw.githubusercontent.com/s2ward/tibia/main/api/npc_data.json"
+# If the file is not a link, provide the file path like this:
+# NPC_JSON = "path/to/npc_data.json"
+
+# The name of the output JSON file with updated data
+OUT_FILENAME = "npc_data.json"
+
+# The zoom level for the tibiamaps.io link
+TIBIAMAPS_ZOOM = 2;  # ranges from 0-4, where 4 is maximum zoom
+
+# Function to convert the given URL to TibiaMaps coordinates
+def fandomMapperToTibiaMaps(url):
+    if url == "":
+        return
+
+    # Extract x, y, and z values from the URL
+    x, y, z = url.split("=")[1].split("-")[:3]
+
+    # Calculate Y-coordinate for tibiamaps.io
+    Y = 31999
+    y1, y2 = y.split(".")
+    yn1 = int(y1) - 125
+    yf = Y + int(y2) + (yn1 * 255) + yn1
+
+    # Calculate X-coordinate for tibiamaps.io
+    X = 32000
+    x1, x2 = x.split(".")
+    xn1 = int(x1) - 125
+    xf = X + int(x2) + (xn1 * 255) + xn1
+
+    # Return the calculated coordinates as integers
+    return xf, yf, int(z)
+
+
+
+# Check if NPC_JSON is a URL or a file path
+if os.path.isfile(NPC_JSON):
+    # If NPC_JSON is a file path, load data from the file
+    with open(NPC_JSON, 'r') as json_file:
+        data = json.load(json_file)
+else:
+    # If NPC_JSON is a URL, fetch JSON data from the URL
+    response = requests.get(NPC_JSON)
+    if response.status_code == 200:
+        data = response.json()
+    else:
+        print(f"Failed to fetch data from {NPC_JSON}")
+        exit()
+
+# Process each item in the JSON data
+for item in data:
+    # Call the function and check if it returns a value
+    coords = fandomMapperToTibiaMaps(item["map"])
+    if coords:
+        # If the function returns a value, unpack the coordinates
+        xf, yf, z = coords
+        item["tibiamap"] = f"https://tibiamaps.io/map#{xf},{yf},{z}:{TIBIAMAPS_ZOOM}"
+        item["coords"] = [xf, yf, z]
+    else:
+        # If the function returns None, set tibiamap and coords to empty values
+        item["tibiamap"] = ""
+        item["coords"] = []
+
+# Convert data back to JSON
+output_json = json.dumps(data, indent=4)
+
+# Save the updated JSON back to the file
+with open(OUT_FILENAME, 'w') as json_file:
+    json_file.write(output_json)


### PR DESCRIPTION
Adding `src/mapper_to_tibiamaps.py`, that allows converting Mapper (https://tibia.fandom.com/wiki/Mapper), to Tibiamaps (https://tibiamaps.io).


This adds two new keys to `npc_data.json`
`tibiamap <string>` -  https://tibiamaps.io/map#x,y,z:2
`coords <array>`  [x,y,z]

**Note:**
for frontend, to embed the tibiamaps.io, use the `coords <array>` to generate link like so: 
https://tibiamaps.io/map/embed#x,y,z:2, where `2` is tibiamaps `zoom [0-4]` (4 is maximum)

**Note 2:**
In future, advised it to get rid of the following keys in `npc_data.json`
`tibiamap <string>` 
`map <string>` 
so that we will only use
`coords <array>`  [x,y,z]
to generate any kind of link/embeds on frontend
